### PR TITLE
C++ optimization and abi3 wheel support for portable binaries

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.13', '3.14.0-beta.4', 'pypy-3.9', 'pypy-3.11']
+        # Test across Python versions to verify abi3 wheel compatibility
+        # CPython: minimum (3.9), intermediate versions, latest stable
+        # PyPy: versions we build wheels for
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.9', 'pypy-3.10']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: tests
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "*" ]
+    branches: [ "main" ]
 
 jobs:
   prepare-cache:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,14 +49,17 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         # Options (https://cibuildwheel.readthedocs.io/en/stable/options/)
         env:
-          CIBW_SKIP: cp36-* cp37-* cp38-* pp37-* pp38-* *musllinux* *win_pp* 
+          # Build abi3 wheel for CPython 3.9+ (one wheel for all versions)
+          # Build version-specific wheels for PyPy (which doesn't support abi3)
+          CIBW_BUILD: cp39-* pp39-* pp310-*
+          CIBW_SKIP: "*musllinux* *win_pp*"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
           CIBW_BEFORE_BUILD_MACOS: python3 -m pip install --upgrade setuptools wheel cffi
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_BEFORE_BUILD_WINDOWS: python -m pip install "setuptools<72"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_BUILD_FRONTEND: "build"
-          # CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,7 @@ log/
 console/
 
 # Virtual environments
-venv
+venv*/
 p3*/
 pypy*/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,16 @@ python tools/binpack.py
 python tools/dawgbuilder.py
 ```
 
+### Rebuilding C++ Extensions
+
+**Always use `pip install -e .` to rebuild C++ extensions** (not `bin_build.py` directly):
+
+```bash
+{path-to-venv}/bin/python -m pip install -e . --no-build-isolation
+```
+
+Running `bin_build.py` directly creates `.so` files in the wrong location (`islenska/` instead of `src/islenska/`) because it doesn't respect the `src/` layout from `pyproject.toml`.
+
 ### Testing
 ```bash
 # Run all tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "cffi>=1.15.1"]
+requires = ["setuptools>=61.0", "cffi>=1.15.1", "wheel>=0.38.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,20 @@ This file is retained for CFFI compilation.
 All package metadata is defined in pyproject.toml.
 """
 
+import platform
 from setuptools import setup
 
 # The cffi_modules and zip_safe settings are not yet supported in pyproject.toml
 # and must be defined here.
+
+# Use stable ABI for CPython to create portable wheels across Python versions
+# PyPy doesn't support the stable ABI, so we skip this for PyPy builds
+options = {}
+if platform.python_implementation() == "CPython":
+    options["py_limited_api"] = "cp39"  # Requires Python 3.9+
+
 setup(
     zip_safe=True,
     cffi_modules=["src/islenska/bin_build.py:ffibuilder"],
+    options={"bdist_wheel": options},
 )

--- a/src/islenska/bin_build.py
+++ b/src/islenska/bin_build.py
@@ -54,10 +54,18 @@ IMPLEMENTATION = platform.python_implementation()
 
 declarations = """
 
+    // From bin.h
     typedef unsigned int UINT;
     typedef uint8_t BYTE;
-
     UINT mapping(const BYTE* pbMap, const BYTE* pszWordLatin);
+
+    // From dawgdictionary.h
+    typedef void* DawgHandle;
+    DawgHandle dawg_load(const BYTE* pbMap);
+    void dawg_unload(DawgHandle handle);
+    bool dawg_contains(DawgHandle handle, const char* word);
+    char* dawg_find_combinations(DawgHandle handle, const char* word);
+    void dawg_free_string(char* str);
 
 """
 
@@ -89,7 +97,7 @@ ffibuilder.set_source(  # type: ignore
     # This is the reason for the "extern 'C' { ... }" wrapper.
     'extern "C" {\n' + declarations + "\n}\n",
     source_extension=".cpp",
-    sources=["src/islenska/bin.cpp"],
+    sources=["src/islenska/bin.cpp", "src/islenska/dawgdictionary.cpp"],
     extra_compile_args=extra_compile_args,
     extra_link_args=extra_link_args,
 )

--- a/src/islenska/bin_build.py
+++ b/src/islenska/bin_build.py
@@ -102,6 +102,10 @@ if IMPLEMENTATION == "PyPy":
 
 ffibuilder.cdef(declarations)  # type: ignore
 
+# Use stable ABI for CPython to create portable wheels across Python versions.
+# PyPy doesn't support the stable ABI, so we create version-specific wheels for it.
+py_limited_api = "cp39" if IMPLEMENTATION == "CPython" else False
+
 ffibuilder.set_source(  # type: ignore
     "islenska._bin",
     # bin.cpp is written in C++ but must export a pure C interface.
@@ -111,6 +115,7 @@ ffibuilder.set_source(  # type: ignore
     sources=["src/islenska/bin.cpp", "src/islenska/dawgdictionary.cpp", "src/islenska/bincompress.cpp"],
     extra_compile_args=extra_compile_args,
     extra_link_args=extra_link_args,
+    py_limited_api=py_limited_api,
 )
 
 if __name__ == "__main__":

--- a/src/islenska/bin_build.py
+++ b/src/islenska/bin_build.py
@@ -67,6 +67,14 @@ declarations = """
     char* dawg_find_combinations(DawgHandle handle, const char* word);
     void dawg_free_string(char* str);
 
+    // From bincompress.h
+    typedef void* BinCompressedHandle;
+    BinCompressedHandle bin_compressed_init(const BYTE* pbMap);
+    void bin_compressed_close(BinCompressedHandle handle);
+    bool bin_compressed_contains(BinCompressedHandle handle, const char* word);
+    char* bin_compressed_lookup(BinCompressedHandle handle, const char* word, const char* cat, const char* lemma, int utg);
+    void bin_compressed_free_string(char* str);
+
 """
 
 # Do the magic CFFI incantations necessary to get CFFI and setuptools
@@ -97,7 +105,7 @@ ffibuilder.set_source(  # type: ignore
     # This is the reason for the "extern 'C' { ... }" wrapper.
     'extern "C" {\n' + declarations + "\n}\n",
     source_extension=".cpp",
-    sources=["src/islenska/bin.cpp", "src/islenska/dawgdictionary.cpp"],
+    sources=["src/islenska/bin.cpp", "src/islenska/dawgdictionary.cpp", "src/islenska/bincompress.cpp"],
     extra_compile_args=extra_compile_args,
     extra_link_args=extra_link_args,
 )

--- a/src/islenska/bin_build.py
+++ b/src/islenska/bin_build.py
@@ -68,12 +68,12 @@ declarations = """
     void dawg_free_string(char* str);
 
     // From bincompress.h
-    typedef void* BinCompressedHandle;
-    BinCompressedHandle bin_compressed_init(const BYTE* pbMap);
-    void bin_compressed_close(BinCompressedHandle handle);
-    bool bin_compressed_contains(BinCompressedHandle handle, const char* word);
-    char* bin_compressed_lookup(BinCompressedHandle handle, const char* word, const char* cat, const char* lemma, int utg);
-    char* bin_compressed_lookup_ksnid(BinCompressedHandle handle, const char* word, const char* cat, const char* lemma, int utg);
+    typedef void* BcHandle;
+    BcHandle bin_compressed_init(const BYTE* pbMap);
+    void bin_compressed_close(BcHandle handle);
+    bool bin_compressed_contains(BcHandle handle, const char* word);
+    char* bin_compressed_lookup(BcHandle handle, const char* word, const char* cat, const char* lemma, int utg);
+    char* bin_compressed_lookup_ksnid(BcHandle handle, const char* word, const char* cat, const char* lemma, int utg);
     void bin_compressed_free_string(char* str);
 
 """

--- a/src/islenska/bin_build.py
+++ b/src/islenska/bin_build.py
@@ -75,6 +75,7 @@ declarations = """
     char* bin_compressed_lookup(BcHandle handle, const char* word, const char* cat, const char* lemma, int utg);
     char* bin_compressed_lookup_ksnid(BcHandle handle, const char* word, const char* cat, const char* lemma, int utg);
     char* bin_compressed_lemma_forms(BcHandle handle, int bin_id);
+    char* bin_compressed_lookup_id(BcHandle handle, int bin_id);
     void bin_compressed_free_string(char* str);
 
 """

--- a/src/islenska/bin_build.py
+++ b/src/islenska/bin_build.py
@@ -73,6 +73,7 @@ declarations = """
     void bin_compressed_close(BinCompressedHandle handle);
     bool bin_compressed_contains(BinCompressedHandle handle, const char* word);
     char* bin_compressed_lookup(BinCompressedHandle handle, const char* word, const char* cat, const char* lemma, int utg);
+    char* bin_compressed_lookup_ksnid(BinCompressedHandle handle, const char* word, const char* cat, const char* lemma, int utg);
     void bin_compressed_free_string(char* str);
 
 """

--- a/src/islenska/bin_build.py
+++ b/src/islenska/bin_build.py
@@ -74,6 +74,7 @@ declarations = """
     bool bin_compressed_contains(BcHandle handle, const char* word);
     char* bin_compressed_lookup(BcHandle handle, const char* word, const char* cat, const char* lemma, int utg);
     char* bin_compressed_lookup_ksnid(BcHandle handle, const char* word, const char* cat, const char* lemma, int utg);
+    char* bin_compressed_lemma_forms(BcHandle handle, int bin_id);
     void bin_compressed_free_string(char* str);
 
 """

--- a/src/islenska/bincompress.cpp
+++ b/src/islenska/bincompress.cpp
@@ -559,7 +559,7 @@ std::vector<KsnidEntry> BinCompressed::lookup_ksnid(
 // C API implementation
 // ============================================================================
 
-BinCompressedHandle bin_compressed_init(const BYTE* pbMap) {
+BcHandle bin_compressed_init(const BYTE* pbMap) {
     try {
         return new BinCompressed(pbMap);
     } catch (...) {
@@ -567,13 +567,13 @@ BinCompressedHandle bin_compressed_init(const BYTE* pbMap) {
     }
 }
 
-void bin_compressed_close(BinCompressedHandle handle) {
+void bin_compressed_close(BcHandle handle) {
     if (handle) {
         delete static_cast<BinCompressed*>(handle);
     }
 }
 
-bool bin_compressed_contains(BinCompressedHandle handle, const char* word) {
+bool bin_compressed_contains(BcHandle handle, const char* word) {
     if (!handle || !word) return false;
     return static_cast<BinCompressed*>(handle)->contains(word);
 }
@@ -662,7 +662,7 @@ static char* serialize_ksnid_entries(const std::vector<KsnidEntry>& entries) {
 }
 
 char* bin_compressed_lookup(
-    BinCompressedHandle handle,
+    BcHandle handle,
     const char* word,
     const char* cat,
     const char* lemma,
@@ -679,7 +679,7 @@ char* bin_compressed_lookup(
 }
 
 char* bin_compressed_lookup_ksnid(
-    BinCompressedHandle handle,
+    BcHandle handle,
     const char* word,
     const char* cat,
     const char* lemma,

--- a/src/islenska/bincompress.cpp
+++ b/src/islenska/bincompress.cpp
@@ -148,6 +148,7 @@ private:
     UINT m_forms_offset;              // Offset to forms trie
     const BYTE* m_mappings;           // Pointer to mappings section
     const BYTE* m_lemmas;             // Pointer to lemmas section
+    const BYTE* m_templates;          // Pointer to templates section
     const BYTE* m_meanings;           // Pointer to meanings section
     const BYTE* m_ksnid_strings;      // Pointer to ksnid section
     std::vector<std::string> m_subcats;  // Subcategory strings
@@ -212,6 +213,18 @@ public:
      * @return Pair of (stofn, fl) strings
      */
     std::pair<std::string, std::string> lemma(int bin_id) const;
+
+    /**
+     * Get all word forms associated with a lemma.
+     *
+     * Returns all inflected forms of the lemma identified by bin_id,
+     * decompressed from the templates section. The result includes
+     * the base lemma form as well as all inflected variants.
+     *
+     * @param bin_id BÍN ID number
+     * @return Vector of Latin-1 encoded word forms (as strings)
+     */
+    std::vector<std::string> lemma_forms(int bin_id) const;
 
     /**
      * Perform raw lookup of a word form.
@@ -279,7 +292,7 @@ BinCompressed::BinCompressed(const BYTE* pbMap) : m_pbMap(pbMap) {
     UINT mappings_offset = read_uint32(16);
     m_forms_offset = read_uint32(20);
     UINT lemmas_offset = read_uint32(24);
-    // UINT templates_offset = read_uint32(28);  // Not currently used
+    UINT templates_offset = read_uint32(28);
     UINT meanings_offset = read_uint32(32);
     // UINT alphabet_offset = read_uint32(36);  // Not currently used
     UINT subcats_offset = read_uint32(40);
@@ -290,6 +303,7 @@ BinCompressed::BinCompressed(const BYTE* pbMap) : m_pbMap(pbMap) {
     // Set section pointers
     m_mappings = m_pbMap + mappings_offset;
     m_lemmas = m_pbMap + lemmas_offset;
+    m_templates = m_pbMap + templates_offset;
     m_meanings = m_pbMap + meanings_offset;
     m_ksnid_strings = m_pbMap + ksnid_offset;
 
@@ -381,6 +395,109 @@ std::pair<std::string, std::string> BinCompressed::lemma(int bin_id) const {
     std::string fl = (cix < m_subcats.size()) ? m_subcats[cix] : "";
 
     return std::make_pair(stofn, fl);
+}
+
+std::vector<std::string> BinCompressed::lemma_forms(int bin_id) const {
+    // Sanity check on the BÍN id
+    if (bin_id < 0 || (UINT)bin_id > m_max_bin_id) {
+        return std::vector<std::string>();
+    }
+
+    // Read offset to lemma entry
+    UINT off = read_uint32(m_lemmas + bin_id * 4);
+    if (off == 0) {
+        // No entry with this BÍN id
+        return std::vector<std::string>();
+    }
+
+    // Read flags/bits
+    UINT bits = read_uint32(off);
+
+    // Skip past the flags to read the lemma string (length-prefixed)
+    UINT p = off + 4;
+    UINT lw = m_pbMap[p];  // Length byte
+
+    // Extract the base lemma (at p+1)
+    std::string lemma(reinterpret_cast<const char*>(m_pbMap + p + 1), lw);
+
+    // Check if templates are attached (bit 0x80000000)
+    if ((bits & 0x80000000) == 0) {
+        // No templates associated with this lemma
+        return std::vector<std::string>{lemma};
+    }
+
+    // Skip past the lemma to get to the template pointer
+    // The lemma is 4-byte aligned: length byte (1) + string (lw) + padding
+    lw += 1;  // Include the length byte
+    if (lw & 3) {
+        lw += 4 - (lw & 3);  // Round up to next multiple of 4
+    }
+    p += lw;  // Now p points to template offset
+
+    // Read the template set offset
+    UINT template_offset = read_uint32(p);
+
+    // Decompress the template set using differential encoding
+    std::vector<std::string> result;
+    std::string last_w = lemma;
+    size_t last_len = lemma.length();
+    p = template_offset;
+
+    while (true) {
+        // Read the cut byte
+        BYTE cut_byte = m_templates[p];
+        p += 1;
+
+        if (cut_byte == 0x00) {
+            // End of template set
+            break;
+        }
+
+        size_t cut;
+        size_t new_len;
+
+        if (cut_byte & 0x80) {
+            // Long form: cut is in lower 7 bits, length in next byte
+            cut = cut_byte & 0x7F;
+            new_len = m_templates[p];
+            p += 1;
+        } else {
+            // Short form: cut in upper bits, length difference in lower bits
+            int diff = static_cast<int>(cut_byte & 0x03) - static_cast<int>(cut_byte & 0x04);
+            cut = cut_byte >> 3;
+            // diff can be negative, so we need to handle the sign carefully
+            int new_len_signed = static_cast<int>(cut) + diff;
+            if (new_len_signed < 0 || new_len_signed > 255) {
+                // Invalid new_len - would wrap around or be too large
+                return std::vector<std::string>();
+            }
+            new_len = static_cast<size_t>(new_len_signed);
+        }
+
+        // Calculate the common prefix length
+        if (cut > last_len) {
+            // Invalid data - cut is larger than previous word length
+            return std::vector<std::string>();
+        }
+        size_t common = last_len - cut;
+
+        // Assemble the new word: common prefix + divergent part
+        std::string w = last_w.substr(0, common) +
+            std::string(reinterpret_cast<const char*>(m_templates + p), new_len);
+        p += new_len;
+
+        // Add to results
+        result.push_back(w);
+
+        // Update for next iteration
+        last_w = w;
+        last_len = common + new_len;
+    }
+
+    // Append the base lemma itself
+    result.push_back(lemma);
+
+    return result;
 }
 
 std::vector<RawEntry> BinCompressed::raw_lookup(const char* word) const {
@@ -671,6 +788,23 @@ static char* serialize_ksnid_entries(const std::vector<KsnidEntry>& entries) {
     return result;
 }
 
+static char* serialize_lemma_forms(const std::vector<std::string>& forms) {
+    std::stringstream ss;
+    ss << "[";
+    for (size_t i = 0; i < forms.size(); ++i) {
+        if (i > 0) ss << ",";
+        ss << "\"";
+        append_latin1_as_utf8(ss, forms[i]);
+        ss << "\"";
+    }
+    ss << "]";
+
+    std::string s = ss.str();
+    char* result = new char[s.length() + 1];
+    std::strcpy(result, s.c_str());
+    return result;
+}
+
 char* bin_compressed_lookup(
     BcHandle handle,
     const char* word,
@@ -703,6 +837,20 @@ char* bin_compressed_lookup_ksnid(
     }
 
     return serialize_ksnid_entries(entries);
+}
+
+char* bin_compressed_lemma_forms(BcHandle handle, int bin_id) {
+    if (!handle) {
+        return nullptr;
+    }
+
+    auto forms = static_cast<BinCompressed*>(handle)->lemma_forms(bin_id);
+
+    if (forms.empty()) {
+        return nullptr;
+    }
+
+    return serialize_lemma_forms(forms);
 }
 
 void bin_compressed_free_string(char* str) {

--- a/src/islenska/bincompress.cpp
+++ b/src/islenska/bincompress.cpp
@@ -123,6 +123,20 @@ struct BinEntry {
 };
 
 /**
+ * Structure to hold a Ksnid entry.
+ * Corresponds to Ksnid.from_parameters(ord, bin_id, ofl, hluti, form, mark, ksnid)
+ */
+struct KsnidEntry {
+    std::string ord;        // Lemma (stofn)
+    int bin_id;             // BÍN id
+    std::string ofl;        // Word category
+    std::string hluti;      // Subcategory (fl)
+    std::string form;       // Word form
+    std::string mark;       // Inflection marks (beyging)
+    std::string ksnid;      // Ksnid string
+};
+
+/**
  * Main BinCompressed class.
  *
  * Wraps a memory-mapped compressed BÍN dictionary file and provides
@@ -227,6 +241,22 @@ public:
      * @return Vector of BinEntry structures
      */
     std::vector<BinEntry> lookup(
+        const char* word,
+        const char* cat = nullptr,
+        const char* lemma = nullptr,
+        int utg = -1
+    ) const;
+
+    /**
+     * Lookup a word and return all matching Ksnid entries.
+     *
+     * @param word Latin-1 encoded word to lookup
+     * @param cat Optional word category filter (NULL for no filter)
+     * @param lemma Optional lemma filter (NULL for no filter)
+     * @param utg Optional BÍN ID filter (-1 for no filter)
+     * @return Vector of KsnidEntry structures
+     */
+    std::vector<KsnidEntry> lookup_ksnid(
         const char* word,
         const char* cat = nullptr,
         const char* lemma = nullptr,
@@ -463,6 +493,68 @@ std::vector<BinEntry> BinCompressed::lookup(
     return result;
 }
 
+std::vector<KsnidEntry> BinCompressed::lookup_ksnid(
+    const char* word,
+    const char* cat,
+    const char* lemma_filter,
+    int utg
+) const {
+    std::vector<KsnidEntry> result;
+
+    // Get raw entries
+    std::vector<RawEntry> raw_entries = raw_lookup(word);
+
+    for (const auto& raw : raw_entries) {
+        // Apply utg filter
+        if (utg != -1 && raw.bin_id != utg) {
+            continue;
+        }
+
+        // Get meaning
+        std::pair<std::string, std::string> meaning_pair = meaning(raw.meaning_index);
+        std::string ofl = meaning_pair.first;
+        std::string beyging = meaning_pair.second;
+
+        // Apply category filter
+        if (cat != nullptr) {
+            // Special case: "no" matches any gender (kk, kvk, hk)
+            if (strcmp(cat, "no") == 0) {
+                if (ofl != "kk" && ofl != "kvk" && ofl != "hk") {
+                    continue;
+                }
+            } else if (ofl != cat) {
+                continue;
+            }
+        }
+
+        // Get lemma
+        std::pair<std::string, std::string> lemma_pair = lemma(raw.bin_id);
+        std::string stofn = lemma_pair.first;
+        std::string fl = lemma_pair.second;
+
+        // Apply lemma filter
+        if (lemma_filter != nullptr && stofn != lemma_filter) {
+            continue;
+        }
+
+        // Get ksnid string
+        std::string ksnid_str = ksnid_string(raw.ksnid_index);
+
+        // Create entry
+        KsnidEntry entry;
+        entry.ord = stofn;
+        entry.bin_id = raw.bin_id;
+        entry.ofl = ofl;
+        entry.hluti = fl;
+        entry.form = word;
+        entry.mark = beyging;
+        entry.ksnid = ksnid_str;
+        result.push_back(entry);
+    }
+
+    return result;
+}
+
 // ============================================================================
 // C API implementation
 // ============================================================================
@@ -542,6 +634,33 @@ static char* serialize_entries(const std::vector<BinEntry>& entries) {
     return result;
 }
 
+static char* serialize_ksnid_entries(const std::vector<KsnidEntry>& entries) {
+    std::stringstream ss;
+    ss << "[";
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (i > 0) ss << ",";
+        ss << "{\"ord\":\"";
+        append_latin1_as_utf8(ss, entries[i].ord);
+        ss << "\",\"bin_id\":" << entries[i].bin_id << ",\"ofl\":\"";
+        append_latin1_as_utf8(ss, entries[i].ofl);
+        ss << "\",\"hluti\":\"";
+        append_latin1_as_utf8(ss, entries[i].hluti);
+        ss << "\",\"form\":\"";
+        append_latin1_as_utf8(ss, entries[i].form);
+        ss << "\",\"mark\":\"";
+        append_latin1_as_utf8(ss, entries[i].mark);
+        ss << "\",\"ksnid\":\"";
+        append_latin1_as_utf8(ss, entries[i].ksnid);
+        ss << "\"}";
+    }
+    ss << "]";
+
+    std::string s = ss.str();
+    char* result = new char[s.length() + 1];
+    std::strcpy(result, s.c_str());
+    return result;
+}
+
 char* bin_compressed_lookup(
     BinCompressedHandle handle,
     const char* word,
@@ -557,6 +676,23 @@ char* bin_compressed_lookup(
     }
 
     return serialize_entries(entries);
+}
+
+char* bin_compressed_lookup_ksnid(
+    BinCompressedHandle handle,
+    const char* word,
+    const char* cat,
+    const char* lemma,
+    int utg
+) {
+    if (!handle || !word) return nullptr;
+
+    auto entries = static_cast<BinCompressed*>(handle)->lookup_ksnid(word, cat, lemma, utg);
+    if (entries.empty()) {
+        return nullptr;
+    }
+
+    return serialize_ksnid_entries(entries);
 }
 
 void bin_compressed_free_string(char* str) {

--- a/src/islenska/bincompress.cpp
+++ b/src/islenska/bincompress.cpp
@@ -249,9 +249,9 @@ BinCompressed::BinCompressed(const BYTE* pbMap) : m_pbMap(pbMap) {
     UINT mappings_offset = read_uint32(16);
     m_forms_offset = read_uint32(20);
     UINT lemmas_offset = read_uint32(24);
-    UINT templates_offset = read_uint32(28);
+    // UINT templates_offset = read_uint32(28);  // Not currently used
     UINT meanings_offset = read_uint32(32);
-    UINT alphabet_offset = read_uint32(36);
+    // UINT alphabet_offset = read_uint32(36);  // Not currently used
     UINT subcats_offset = read_uint32(40);
     UINT ksnid_offset = read_uint32(44);
     m_begin_greynir_utg = read_uint32(48);
@@ -332,7 +332,7 @@ std::pair<std::string, std::string> BinCompressed::lemma(int bin_id) const {
     UINT bits = read_uint32(off) & 0x7FFFFFFF;
 
     // Extract subcategory index (lower SUBCAT_BITS)
-    int cix = bits & ((1 << SUBCAT_BITS) - 1);
+    size_t cix = bits & ((1 << SUBCAT_BITS) - 1);
 
     // Read lemma string (length-prefixed)
     UINT p = off + 4;
@@ -423,7 +423,9 @@ std::vector<BinEntry> BinCompressed::lookup(
         }
 
         // Get meaning
-        auto [ofl, beyging] = meaning(raw.meaning_index);
+        std::pair<std::string, std::string> meaning_pair = meaning(raw.meaning_index);
+        std::string ofl = meaning_pair.first;
+        std::string beyging = meaning_pair.second;
 
         // Apply category filter
         if (cat != nullptr) {
@@ -438,7 +440,9 @@ std::vector<BinEntry> BinCompressed::lookup(
         }
 
         // Get lemma
-        auto [stofn, fl] = lemma(raw.bin_id);
+        std::pair<std::string, std::string> lemma_pair = lemma(raw.bin_id);
+        std::string stofn = lemma_pair.first;
+        std::string fl = lemma_pair.second;
 
         // Apply lemma filter
         if (lemma_filter != nullptr && stofn != lemma_filter) {

--- a/src/islenska/bincompress.cpp
+++ b/src/islenska/bincompress.cpp
@@ -1,0 +1,562 @@
+/*
+
+   BinPackage
+
+   C++ BinCompressed dictionary module
+
+   Copyright © 2025 Miðeind ehf.
+   Original author: Vilhjálmur Þorsteinsson
+
+   This software is licensed under the MIT License:
+
+      Permission is hereby granted, free of charge, to any person
+      obtaining a copy of this software and associated documentation
+      files (the "Software"), to deal in the Software without restriction,
+      including without limitation the rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the Software,
+      and to permit persons to whom the Software is furnished to do so,
+      subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be
+      included in all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   --------------------------------------------------------------------------
+
+   This module provides C++ access to the compressed BÍN dictionary format.
+
+   COMPRESSED DICTIONARY FORMAT:
+
+   The binary file contains multiple sections accessed via offsets:
+
+   [Header - 56 bytes]
+     - Signature: 16 bytes (BIN_COMPRESSOR_VERSION)
+     - Offsets: 10 × 4-byte uint32 values:
+       * mappings_offset
+       * forms_offset
+       * lemmas_offset
+       * templates_offset
+       * meanings_offset
+       * alphabet_offset
+       * subcats_offset
+       * ksnid_offset
+       * begin_greynir_utg
+       * max_bin_id
+
+   [Forms Section]
+     Trie structure for word form lookups (accessed via bin.cpp)
+
+   [Mappings Section]
+     Maps word forms to (bin_id, meaning_index, ksnid_index) tuples.
+     Uses packed 32-bit format for space efficiency:
+     - Type 0x60000000: Single 32-bit packed entry
+     - Type 0x40000000: Same bin_id as previous entry
+     - Type 0x00000000: Two 32-bit words
+
+   [Lemmas Section]
+     Indexed by bin_id. Each entry contains:
+     - Flags/subcat bits (32-bit)
+     - Lemma string (length-prefixed Latin-1)
+     - Optional template reference (if flag 0x80000000 set)
+
+   [Meanings Section]
+     Indexed by meaning_index. Contains (ofl, beyging) strings.
+
+   [KSNIDs Section]
+     Indexed by ksnid_index. Contains KRISTINsnid strings.
+
+   [Subcats Section]
+     List of subcategory ('fl') strings.
+
+*/
+
+#include <string>
+#include <vector>
+#include <cstring>
+#include <sstream>
+#include <stdexcept>
+
+#include "bincompress.h"
+
+// Import the mapping() function from bin.cpp
+extern "C" UINT mapping(const BYTE* pbMap, const BYTE* pbWordLatin);
+
+// Constants from basics.py
+static const int BIN_ID_BITS = 20;         // Line 74
+static const UINT BIN_ID_MASK = 0xFFFFF;   // 2^20 - 1 = 1,048,575
+static const int MEANING_BITS = 10;        // Line 78
+static const UINT MEANING_MASK = 0x3FF;    // 2^10 - 1 = 1,023
+static const int KSNID_BITS = 14;          // Line 82
+static const UINT KSNID_MASK = 0x3FFF;     // 2^14 - 1 = 16,383
+static const int SUBCAT_BITS = 8;          // Line 87 (for subcategory 'hluti')
+static const int COMMON_KIX_0 = 0;         // Line 94
+static const int COMMON_KIX_1 = 1;         // Line 95
+
+/**
+ * Structure to hold raw lookup results.
+ * Corresponds to (bin_id, meaning_index, ksnid_index) tuples in Python.
+ */
+struct RawEntry {
+    int bin_id;
+    int meaning_index;
+    int ksnid_index;
+};
+
+/**
+ * Structure to hold a BÍN entry.
+ * Corresponds to BinEntryTuple: (stofn, utg, ofl, fl, ordmynd, beyging)
+ */
+struct BinEntry {
+    std::string stofn;      // Lemma
+    int utg;                // BÍN id
+    std::string ofl;        // Word category (kk, kvk, hk, so, lo, etc.)
+    std::string fl;         // Subcategory
+    std::string ordmynd;    // Word form
+    std::string beyging;    // Inflection description
+};
+
+/**
+ * Main BinCompressed class.
+ *
+ * Wraps a memory-mapped compressed BÍN dictionary file and provides
+ * efficient lookup operations.
+ */
+class BinCompressed {
+private:
+    const BYTE* m_pbMap;              // Pointer to memory-mapped file
+    UINT m_forms_offset;              // Offset to forms trie
+    const BYTE* m_mappings;           // Pointer to mappings section
+    const BYTE* m_lemmas;             // Pointer to lemmas section
+    const BYTE* m_meanings;           // Pointer to meanings section
+    const BYTE* m_ksnid_strings;      // Pointer to ksnid section
+    std::vector<std::string> m_subcats;  // Subcategory strings
+    UINT m_begin_greynir_utg;         // First Greynir addition ID
+    UINT m_max_bin_id;                // Maximum BÍN ID
+
+    /**
+     * Read a 32-bit little-endian unsigned integer at offset.
+     */
+    inline UINT read_uint32(UINT offset) const {
+        return (m_pbMap[offset + 0] <<  0) |
+               (m_pbMap[offset + 1] <<  8) |
+               (m_pbMap[offset + 2] << 16) |
+               (m_pbMap[offset + 3] << 24);
+    }
+
+    /**
+     * Read a 32-bit little-endian unsigned integer from a byte pointer.
+     */
+    inline UINT read_uint32(const BYTE* p) const {
+        return (p[0] <<  0) |
+               (p[1] <<  8) |
+               (p[2] << 16) |
+               (p[3] << 24);
+    }
+
+public:
+    /**
+     * Initialize BinCompressed from a memory-mapped file.
+     *
+     * @param pbMap Pointer to the memory-mapped compressed dictionary
+     * @throws std::runtime_error if file signature is invalid
+     */
+    BinCompressed(const BYTE* pbMap);
+    ~BinCompressed();
+
+    /**
+     * Get the beginning Greynir utg number.
+     */
+    UINT begin_greynir_utg() const { return m_begin_greynir_utg; }
+
+    /**
+     * Decode a meaning entry.
+     *
+     * @param ix Meaning index
+     * @return Pair of (ofl, beyging) strings
+     */
+    std::pair<std::string, std::string> meaning(int ix) const;
+
+    /**
+     * Decode a KRISTINsnid string.
+     *
+     * @param ix KSNid index
+     * @return KSNid string
+     */
+    std::string ksnid_string(int ix) const;
+
+    /**
+     * Decode a lemma entry.
+     *
+     * @param bin_id BÍN ID number
+     * @return Pair of (stofn, fl) strings
+     */
+    std::pair<std::string, std::string> lemma(int bin_id) const;
+
+    /**
+     * Perform raw lookup of a word form.
+     *
+     * Returns all (bin_id, meaning_index, ksnid_index) tuples for the word.
+     *
+     * @param word Latin-1 encoded word to lookup
+     * @return Vector of raw entries
+     */
+    std::vector<RawEntry> raw_lookup(const char* word) const;
+
+    /**
+     * Check if a word exists in the dictionary.
+     *
+     * @param word Latin-1 encoded word
+     * @return true if word exists, false otherwise
+     */
+    bool contains(const char* word) const;
+
+    /**
+     * Lookup a word and return all matching BÍN entries.
+     *
+     * @param word Latin-1 encoded word to lookup
+     * @param cat Optional word category filter (NULL for no filter)
+     * @param lemma Optional lemma filter (NULL for no filter)
+     * @param utg Optional BÍN ID filter (-1 for no filter)
+     * @return Vector of BinEntry structures
+     */
+    std::vector<BinEntry> lookup(
+        const char* word,
+        const char* cat = nullptr,
+        const char* lemma = nullptr,
+        int utg = -1
+    ) const;
+};
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+BinCompressed::BinCompressed(const BYTE* pbMap) : m_pbMap(pbMap) {
+    // Expected signature (from basics.py BIN_COMPRESSOR_VERSION)
+    const char* expected_sig = "Greynir 04.00.00";
+    if (memcmp(m_pbMap, expected_sig, 16) != 0) {
+        throw std::runtime_error("Invalid compressed dictionary signature");
+    }
+
+    // Read header (10 uint32 values at offset 16)
+    UINT mappings_offset = read_uint32(16);
+    m_forms_offset = read_uint32(20);
+    UINT lemmas_offset = read_uint32(24);
+    UINT templates_offset = read_uint32(28);
+    UINT meanings_offset = read_uint32(32);
+    UINT alphabet_offset = read_uint32(36);
+    UINT subcats_offset = read_uint32(40);
+    UINT ksnid_offset = read_uint32(44);
+    m_begin_greynir_utg = read_uint32(48);
+    m_max_bin_id = read_uint32(52);
+
+    // Set section pointers
+    m_mappings = m_pbMap + mappings_offset;
+    m_lemmas = m_pbMap + lemmas_offset;
+    m_meanings = m_pbMap + meanings_offset;
+    m_ksnid_strings = m_pbMap + ksnid_offset;
+
+    // Read subcategories
+    UINT subcats_length = read_uint32(subcats_offset);
+    const BYTE* subcats_bytes = m_pbMap + subcats_offset + 4;
+
+    // Split on whitespace (space-separated Latin-1 strings)
+    std::string subcats_str(reinterpret_cast<const char*>(subcats_bytes), subcats_length);
+    std::istringstream iss(subcats_str);
+    std::string subcat;
+    while (iss >> subcat) {
+        m_subcats.push_back(subcat);
+    }
+}
+
+BinCompressed::~BinCompressed() {
+    // Nothing to do - we don't own the memory map
+}
+
+std::pair<std::string, std::string> BinCompressed::meaning(int ix) const {
+    // Read offset to meaning string
+    UINT off = read_uint32(m_meanings + ix * 4);
+
+    // Read up to 24 bytes of Latin-1 data
+    const BYTE* p = m_pbMap + off;
+    char buffer[25];
+    memcpy(buffer, p, 24);
+    buffer[24] = '\0';
+
+    // Parse "ofl beyging ..." (space-separated)
+    std::string s(buffer);
+    size_t first_space = s.find(' ');
+    if (first_space == std::string::npos) {
+        throw std::runtime_error("Invalid meaning format");
+    }
+
+    size_t second_space = s.find(' ', first_space + 1);
+    std::string ofl = s.substr(0, first_space);
+    std::string beyging;
+    if (second_space != std::string::npos) {
+        beyging = s.substr(first_space + 1, second_space - first_space - 1);
+    } else {
+        beyging = s.substr(first_space + 1);
+    }
+
+    return std::make_pair(ofl, beyging);
+}
+
+std::string BinCompressed::ksnid_string(int ix) const {
+    // Read offset to ksnid string
+    UINT off = read_uint32(m_ksnid_strings + ix * 4);
+
+    // First byte is length
+    UINT len = m_pbMap[off];
+
+    // Read Latin-1 string
+    return std::string(reinterpret_cast<const char*>(m_pbMap + off + 1), len);
+}
+
+std::pair<std::string, std::string> BinCompressed::lemma(int bin_id) const {
+    // Read offset to lemma entry
+    UINT off = read_uint32(m_lemmas + bin_id * 4);
+    if (off == 0) {
+        // Return empty strings instead of throwing - some lookups return bin_id 0
+        return std::make_pair("", "");
+    }
+
+    // Read flags/bits
+    UINT bits = read_uint32(off) & 0x7FFFFFFF;
+
+    // Extract subcategory index (lower SUBCAT_BITS)
+    int cix = bits & ((1 << SUBCAT_BITS) - 1);
+
+    // Read lemma string (length-prefixed)
+    UINT p = off + 4;
+    UINT lw = m_pbMap[p];  // Length byte
+    p += 1;
+
+    std::string stofn(reinterpret_cast<const char*>(m_pbMap + p), lw);
+    std::string fl = (cix < m_subcats.size()) ? m_subcats[cix] : "";
+
+    return std::make_pair(stofn, fl);
+}
+
+std::vector<RawEntry> BinCompressed::raw_lookup(const char* word) const {
+    // Call the C++ mapping() function from bin.cpp to find the word in the trie
+    UINT map_offset = mapping(m_pbMap, reinterpret_cast<const BYTE*>(word));
+
+    if (map_offset == 0xFFFFFFFF) {
+        // Word not found
+        return std::vector<RawEntry>();
+    }
+
+    // Decode the mappings
+    std::vector<RawEntry> result;
+    int bin_id = -1;
+
+    while (true) {
+        UINT w0 = read_uint32(m_mappings + map_offset * 4);
+        map_offset += 1;
+
+        int meaning_index;
+        int ksnid_index;
+
+        if ((w0 & 0x60000000) == 0x60000000) {
+            // Single 32-bit packed entry
+            meaning_index = ((w0 >> BIN_ID_BITS) & 0xFF) - 1;  // 8 bits for freq_ix
+            bin_id = w0 & BIN_ID_MASK;
+            ksnid_index = (w0 & 0x10000000) ? COMMON_KIX_1 : COMMON_KIX_0;
+        }
+        else if ((w0 & 0x60000000) == 0x40000000) {
+            // Same bin_id as previous entry
+            meaning_index = (w0 >> KSNID_BITS) & MEANING_MASK;
+            ksnid_index = w0 & KSNID_MASK;
+        }
+        else {
+            // Two 32-bit words
+            bin_id = w0 & BIN_ID_MASK;
+            UINT w1 = read_uint32(m_mappings + map_offset * 4);
+            map_offset += 1;
+            meaning_index = (w1 >> KSNID_BITS) & MEANING_MASK;
+            ksnid_index = w1 & KSNID_MASK;
+        }
+
+        RawEntry entry;
+        entry.bin_id = bin_id;
+        entry.meaning_index = meaning_index;
+        entry.ksnid_index = ksnid_index;
+        result.push_back(entry);
+
+        if (w0 & 0x80000000) {
+            // Last mapping indicator
+            break;
+        }
+    }
+
+    return result;
+}
+
+bool BinCompressed::contains(const char* word) const {
+    UINT map_offset = mapping(m_pbMap, reinterpret_cast<const BYTE*>(word));
+    return map_offset != 0xFFFFFFFF;
+}
+
+std::vector<BinEntry> BinCompressed::lookup(
+    const char* word,
+    const char* cat,
+    const char* lemma_filter,
+    int utg
+) const {
+    std::vector<BinEntry> result;
+
+    // Get raw entries
+    std::vector<RawEntry> raw_entries = raw_lookup(word);
+
+    for (const auto& raw : raw_entries) {
+        // Apply utg filter
+        if (utg != -1 && raw.bin_id != utg) {
+            continue;
+        }
+
+        // Get meaning
+        auto [ofl, beyging] = meaning(raw.meaning_index);
+
+        // Apply category filter
+        if (cat != nullptr) {
+            // Special case: "no" matches any gender (kk, kvk, hk)
+            if (strcmp(cat, "no") == 0) {
+                if (ofl != "kk" && ofl != "kvk" && ofl != "hk") {
+                    continue;
+                }
+            } else if (ofl != cat) {
+                continue;
+            }
+        }
+
+        // Get lemma
+        auto [stofn, fl] = lemma(raw.bin_id);
+
+        // Apply lemma filter
+        if (lemma_filter != nullptr && stofn != lemma_filter) {
+            continue;
+        }
+
+        // Create entry
+        BinEntry entry;
+        entry.stofn = stofn;
+        entry.utg = raw.bin_id;
+        entry.ofl = ofl;
+        entry.fl = fl;
+        entry.ordmynd = word;
+        entry.beyging = beyging;
+        result.push_back(entry);
+    }
+
+    return result;
+}
+
+// ============================================================================
+// C API implementation
+// ============================================================================
+
+BinCompressedHandle bin_compressed_init(const BYTE* pbMap) {
+    try {
+        return new BinCompressed(pbMap);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void bin_compressed_close(BinCompressedHandle handle) {
+    if (handle) {
+        delete static_cast<BinCompressed*>(handle);
+    }
+}
+
+bool bin_compressed_contains(BinCompressedHandle handle, const char* word) {
+    if (!handle || !word) return false;
+    return static_cast<BinCompressed*>(handle)->contains(word);
+}
+
+/**
+ * Append a Latin-1 encoded string to an output stream as UTF-8.
+ *
+ * This is more efficient than creating a temporary string when the result
+ * will be immediately appended to a stream. Latin-1 (ISO-8859-1) maps
+ * directly to Unicode code points 0x00-0xFF. For UTF-8 encoding:
+ * - 0x00-0x7F: Single byte (ASCII)
+ * - 0x80-0xFF: Two bytes (0xC2-0xC3 followed by 0x80-0xBF)
+ *
+ * @param os Output stream to append to
+ * @param latin1 Latin-1 encoded string to convert and append
+ */
+static void append_latin1_as_utf8(std::ostream& os, const std::string& latin1) {
+    for (unsigned char c : latin1) {
+        if (c < 0x80) {
+            // ASCII range: single byte
+            os << c;
+        } else {
+            // Latin-1 extended range: two bytes in UTF-8
+            os << static_cast<char>(0xC0 | (c >> 6));
+            os << static_cast<char>(0x80 | (c & 0x3F));
+        }
+    }
+}
+
+/**
+ * Serialize BinEntry results to JSON format with UTF-8 encoding.
+ *
+ * Converts all Latin-1 strings to UTF-8 for JSON output, allowing
+ * Python's json.loads() to consume the bytes directly without decoding.
+ */
+static char* serialize_entries(const std::vector<BinEntry>& entries) {
+    std::stringstream ss;
+    ss << "[";
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (i > 0) ss << ",";
+        ss << "{\"stofn\":\"";
+        append_latin1_as_utf8(ss, entries[i].stofn);
+        ss << "\",\"utg\":" << entries[i].utg << ",\"ofl\":\"";
+        append_latin1_as_utf8(ss, entries[i].ofl);
+        ss << "\",\"fl\":\"";
+        append_latin1_as_utf8(ss, entries[i].fl);
+        ss << "\",\"ordmynd\":\"";
+        append_latin1_as_utf8(ss, entries[i].ordmynd);
+        ss << "\",\"beyging\":\"";
+        append_latin1_as_utf8(ss, entries[i].beyging);
+        ss << "\"}";
+    }
+    ss << "]";
+
+    std::string s = ss.str();
+    char* result = new char[s.length() + 1];
+    std::strcpy(result, s.c_str());
+    return result;
+}
+
+char* bin_compressed_lookup(
+    BinCompressedHandle handle,
+    const char* word,
+    const char* cat,
+    const char* lemma,
+    int utg
+) {
+    if (!handle || !word) return nullptr;
+
+    auto entries = static_cast<BinCompressed*>(handle)->lookup(word, cat, lemma, utg);
+    if (entries.empty()) {
+        return nullptr;
+    }
+
+    return serialize_entries(entries);
+}
+
+void bin_compressed_free_string(char* str) {
+    if (str) {
+        delete[] str;
+    }
+}

--- a/src/islenska/bincompress.cpp
+++ b/src/islenska/bincompress.cpp
@@ -511,6 +511,11 @@ std::vector<std::string> BinCompressed::lemma_forms(int bin_id) const {
             p += 1;
         } else {
             // Short form: cut in upper bits, length difference in lower bits
+            // Note: The expression below is a bit opaque. It extracts a signed
+            // integer from a 3-bit signed representation. The 0x04 bit is
+            // the sign bit, and the lower (0x01 and 0x02) bits are the magnitude.
+            // 100 (0 minus 4) thus becomes -4, 101 (1 minus 4) becomes -3,
+            // 011 (3 minus 0) becomes +3, etc.
             int diff = static_cast<int>(cut_byte & 0x03) - static_cast<int>(cut_byte & 0x04);
             cut = cut_byte >> 3;
             // diff can be negative, so we need to handle the sign carefully

--- a/src/islenska/bincompress.cpp
+++ b/src/islenska/bincompress.cpp
@@ -200,8 +200,8 @@ public:
     /**
      * Decode a KRISTINsnid string.
      *
-     * @param ix KSNid index
-     * @return KSNid string
+     * @param ix KSnid index
+     * @return KSnid string
      */
     std::string ksnid_string(int ix) const;
 
@@ -312,6 +312,9 @@ BinCompressed::~BinCompressed() {
 
 std::pair<std::string, std::string> BinCompressed::meaning(int ix) const {
     // Read offset to meaning string
+    if (ix < 0) {
+        throw std::runtime_error("Invalid meaning index");
+    }
     UINT off = read_uint32(m_meanings + ix * 4);
 
     // Read up to 24 bytes of Latin-1 data
@@ -326,7 +329,6 @@ std::pair<std::string, std::string> BinCompressed::meaning(int ix) const {
     if (first_space == std::string::npos) {
         throw std::runtime_error("Invalid meaning format");
     }
-
     size_t second_space = s.find(' ', first_space + 1);
     std::string ofl = s.substr(0, first_space);
     std::string beyging;
@@ -340,6 +342,9 @@ std::pair<std::string, std::string> BinCompressed::meaning(int ix) const {
 }
 
 std::string BinCompressed::ksnid_string(int ix) const {
+    if (ix < 0) {
+        throw std::runtime_error("Invalid Ksnid index");
+    }
     // Read offset to ksnid string
     UINT off = read_uint32(m_ksnid_strings + ix * 4);
 
@@ -351,6 +356,9 @@ std::string BinCompressed::ksnid_string(int ix) const {
 }
 
 std::pair<std::string, std::string> BinCompressed::lemma(int bin_id) const {
+    if (bin_id < 0 || (UINT)bin_id > m_max_bin_id) {
+        throw std::runtime_error("Invalid BÍN ID");
+    }
     // Read offset to lemma entry
     UINT off = read_uint32(m_lemmas + bin_id * 4);
     if (off == 0) {
@@ -442,6 +450,7 @@ std::vector<BinEntry> BinCompressed::lookup(
     int utg
 ) const {
     std::vector<BinEntry> result;
+    bool cat_is_no = (cat != nullptr && strcmp(cat, "no") == 0);
 
     // Get raw entries
     std::vector<RawEntry> raw_entries = raw_lookup(word);
@@ -460,7 +469,7 @@ std::vector<BinEntry> BinCompressed::lookup(
         // Apply category filter
         if (cat != nullptr) {
             // Special case: "no" matches any gender (kk, kvk, hk)
-            if (strcmp(cat, "no") == 0) {
+            if (cat_is_no) {
                 if (ofl != "kk" && ofl != "kvk" && ofl != "hk") {
                     continue;
                 }
@@ -500,6 +509,7 @@ std::vector<KsnidEntry> BinCompressed::lookup_ksnid(
     int utg
 ) const {
     std::vector<KsnidEntry> result;
+    bool cat_is_no = (cat != nullptr && strcmp(cat, "no") == 0);
 
     // Get raw entries
     std::vector<RawEntry> raw_entries = raw_lookup(word);
@@ -518,7 +528,7 @@ std::vector<KsnidEntry> BinCompressed::lookup_ksnid(
         // Apply category filter
         if (cat != nullptr) {
             // Special case: "no" matches any gender (kk, kvk, hk)
-            if (strcmp(cat, "no") == 0) {
+            if (cat_is_no) {
                 if (ofl != "kk" && ofl != "kvk" && ofl != "hk") {
                     continue;
                 }

--- a/src/islenska/bincompress.cpp
+++ b/src/islenska/bincompress.cpp
@@ -79,6 +79,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_set>
 #include <cstring>
 #include <sstream>
 #include <stdexcept>
@@ -134,6 +135,42 @@ struct KsnidEntry {
     std::string form;       // Word form
     std::string mark;       // Inflection marks (beyging)
     std::string ksnid;      // Ksnid string
+
+    /**
+     * Equality operator matching Python's Ksnid.__eq__()
+     * Compares all fields: bmynd, mark, bin_id, ord, ofl, hluti, ksnid_string
+     */
+    bool operator==(const KsnidEntry& other) const {
+        return form == other.form       // bmynd
+            && mark == other.mark
+            && bin_id == other.bin_id
+            && ord == other.ord
+            && ofl == other.ofl
+            && hluti == other.hluti
+            && ksnid == other.ksnid;    // ksnid_string
+    }
+};
+
+/**
+ * Hash function for KsnidEntry, matching Python's Ksnid.__hash__()
+ * Hashes only the "primary key" fields: (bin_id, ofl, bmynd, mark)
+ */
+struct KsnidEntryHash {
+    std::size_t operator()(const KsnidEntry& entry) const {
+        // Combine hashes using the same approach as Python's tuple hash
+        std::size_t h1 = std::hash<int>()(entry.bin_id);
+        std::size_t h2 = std::hash<std::string>()(entry.ofl);
+        std::size_t h3 = std::hash<std::string>()(entry.form);  // bmynd
+        std::size_t h4 = std::hash<std::string>()(entry.mark);
+
+        // Simple hash combination (similar to boost::hash_combine)
+        std::size_t seed = 0;
+        seed ^= h1 + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= h2 + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= h3 + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= h4 + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        return seed;
+    }
 };
 
 /**
@@ -275,6 +312,17 @@ public:
         const char* lemma = nullptr,
         int utg = -1
     ) const;
+
+    /**
+     * Get all Ksnid entries for a given BÍN ID.
+     *
+     * Returns all word forms of the lemma identified by bin_id,
+     * with their full Ksnid information.
+     *
+     * @param bin_id BÍN ID number
+     * @return Vector of KsnidEntry structures
+     */
+    std::vector<KsnidEntry> lookup_id(int bin_id) const;
 };
 
 // ============================================================================
@@ -682,6 +730,58 @@ std::vector<KsnidEntry> BinCompressed::lookup_ksnid(
     return result;
 }
 
+std::vector<KsnidEntry> BinCompressed::lookup_id(int bin_id) const {
+    // Get all word forms for this lemma
+    std::vector<std::string> forms = lemma_forms(bin_id);
+    if (forms.empty()) {
+        return std::vector<KsnidEntry>();
+    }
+
+    // Get the lemma (stofn, fl) once
+    std::pair<std::string, std::string> lemma_pair = lemma(bin_id);
+    std::string stofn = lemma_pair.first;
+    std::string fl = lemma_pair.second;
+
+    // Use an unordered_set for O(1) duplicate detection (same as Python's set)
+    std::unordered_set<KsnidEntry, KsnidEntryHash> unique_entries;
+
+    // For each word form, do a raw lookup
+    for (const auto& form : forms) {
+        std::vector<RawEntry> raw_entries = raw_lookup(form.c_str());
+
+        for (const auto& raw : raw_entries) {
+            // Filter to only this bin_id
+            if (raw.bin_id != bin_id) {
+                continue;
+            }
+
+            // Get meaning
+            std::pair<std::string, std::string> meaning_pair = meaning(raw.meaning_index);
+            std::string ofl = meaning_pair.first;
+            std::string beyging = meaning_pair.second;
+
+            // Get ksnid string
+            std::string ksnid_str = ksnid_string(raw.ksnid_index);
+
+            // Create entry
+            KsnidEntry entry;
+            entry.ord = stofn;
+            entry.bin_id = bin_id;
+            entry.ofl = ofl;
+            entry.hluti = fl;
+            entry.form = form;
+            entry.mark = beyging;
+            entry.ksnid = ksnid_str;
+
+            // Insert into set (automatically handles duplicates)
+            unique_entries.insert(entry);
+        }
+    }
+
+    // Convert set to vector for return
+    return std::vector<KsnidEntry>(unique_entries.begin(), unique_entries.end());
+}
+
 // ============================================================================
 // C API implementation
 // ============================================================================
@@ -851,6 +951,20 @@ char* bin_compressed_lemma_forms(BcHandle handle, int bin_id) {
     }
 
     return serialize_lemma_forms(forms);
+}
+
+char* bin_compressed_lookup_id(BcHandle handle, int bin_id) {
+    if (!handle) {
+        return nullptr;
+    }
+
+    auto entries = static_cast<BinCompressed*>(handle)->lookup_id(bin_id);
+
+    if (entries.empty()) {
+        return nullptr;
+    }
+
+    return serialize_ksnid_entries(entries);
 }
 
 void bin_compressed_free_string(char* str) {

--- a/src/islenska/bincompress.h
+++ b/src/islenska/bincompress.h
@@ -123,6 +123,21 @@ char* bin_compressed_lookup_ksnid(
 );
 
 /**
+ * Get all word forms associated with a lemma.
+ *
+ * Returns a JSON array of word forms (as UTF-8 encoded strings):
+ * ["form1", "form2", ..., "lemma"]
+ *
+ * The forms are decompressed from the templates section and include
+ * all inflected variants plus the base lemma itself.
+ *
+ * @param handle Handle returned by bin_compressed_init()
+ * @param bin_id BÍN ID number
+ * @return JSON string (must be freed with bin_compressed_free_string), or NULL if not found
+ */
+char* bin_compressed_lemma_forms(BcHandle handle, int bin_id);
+
+/**
  * Free a string returned by bin_compressed functions.
  *
  * @param str String to free (may be NULL)

--- a/src/islenska/bincompress.h
+++ b/src/islenska/bincompress.h
@@ -99,6 +99,30 @@ char* bin_compressed_lookup(
 );
 
 /**
+ * Lookup a word and return Ksnid results as a JSON string.
+ *
+ * Returns a JSON array of Ksnid objects:
+ * [
+ *   {"ord": "...", "bin_id": 123, "ofl": "...", "hluti": "...", "form": "...", "mark": "...", "ksnid": "..."},
+ *   ...
+ * ]
+ *
+ * @param handle Handle returned by bin_compressed_init()
+ * @param word Latin-1 encoded word to search for
+ * @param cat Optional word category filter (NULL for no filter)
+ * @param lemma Optional lemma filter (NULL for no filter)
+ * @param utg Optional BÍN ID filter (-1 for no filter)
+ * @return JSON string (must be freed with bin_compressed_free_string), or NULL if not found
+ */
+char* bin_compressed_lookup_ksnid(
+    BinCompressedHandle handle,
+    const char* word,
+    const char* cat,
+    const char* lemma,
+    int utg
+);
+
+/**
  * Free a string returned by bin_compressed functions.
  *
  * @param str String to free (may be NULL)

--- a/src/islenska/bincompress.h
+++ b/src/islenska/bincompress.h
@@ -41,7 +41,7 @@ typedef uint8_t BYTE;
 typedef uint32_t UINT;
 
 // Opaque handle for the BinCompressed dictionary
-typedef void* BinCompressedHandle;
+typedef void* BcHandle;
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,14 +56,14 @@ extern "C" {
  * @note The caller must ensure the memory mapping remains valid for the
  *       lifetime of the returned handle.
  */
-BinCompressedHandle bin_compressed_init(const BYTE* pbMap);
+BcHandle bin_compressed_init(const BYTE* pbMap);
 
 /**
  * Close and free a BinCompressed dictionary.
  *
  * @param handle Handle returned by bin_compressed_init()
  */
-void bin_compressed_close(BinCompressedHandle handle);
+void bin_compressed_close(BcHandle handle);
 
 /**
  * Check if a word exists in the dictionary.
@@ -72,7 +72,7 @@ void bin_compressed_close(BinCompressedHandle handle);
  * @param word Latin-1 encoded word to search for
  * @return true if word exists in dictionary, false otherwise
  */
-bool bin_compressed_contains(BinCompressedHandle handle, const char* word);
+bool bin_compressed_contains(BcHandle handle, const char* word);
 
 /**
  * Lookup a word and return results as a JSON string.
@@ -91,7 +91,7 @@ bool bin_compressed_contains(BinCompressedHandle handle, const char* word);
  * @return JSON string (must be freed with bin_compressed_free_string), or NULL if not found
  */
 char* bin_compressed_lookup(
-    BinCompressedHandle handle,
+    BcHandle handle,
     const char* word,
     const char* cat,
     const char* lemma,
@@ -115,7 +115,7 @@ char* bin_compressed_lookup(
  * @return JSON string (must be freed with bin_compressed_free_string), or NULL if not found
  */
 char* bin_compressed_lookup_ksnid(
-    BinCompressedHandle handle,
+    BcHandle handle,
     const char* word,
     const char* cat,
     const char* lemma,

--- a/src/islenska/bincompress.h
+++ b/src/islenska/bincompress.h
@@ -1,0 +1,110 @@
+/*
+
+   BinPackage
+
+   C++ BinCompressed dictionary module
+
+   Copyright © 2025 Miðeind ehf.
+   Original author: Vilhjálmur Þorsteinsson
+
+   This software is licensed under the MIT License:
+
+      Permission is hereby granted, free of charge, to any person
+      obtaining a copy of this software and associated documentation
+      files (the "Software"), to deal in the Software without restriction,
+      including without limitation the rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the Software,
+      and to permit persons to whom the Software is furnished to do so,
+      subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be
+      included in all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <stdint.h>
+
+// C99 bool support (C++ has bool built-in)
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+typedef uint8_t BYTE;
+typedef uint32_t UINT;
+
+// Opaque handle for the BinCompressed dictionary
+typedef void* BinCompressedHandle;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize a BinCompressed dictionary from a memory-mapped file.
+ *
+ * @param pbMap Pointer to the beginning of the compressed dictionary file
+ * @return Handle to the dictionary, or NULL if initialization fails
+ *
+ * @note The caller must ensure the memory mapping remains valid for the
+ *       lifetime of the returned handle.
+ */
+BinCompressedHandle bin_compressed_init(const BYTE* pbMap);
+
+/**
+ * Close and free a BinCompressed dictionary.
+ *
+ * @param handle Handle returned by bin_compressed_init()
+ */
+void bin_compressed_close(BinCompressedHandle handle);
+
+/**
+ * Check if a word exists in the dictionary.
+ *
+ * @param handle Handle returned by bin_compressed_init()
+ * @param word Latin-1 encoded word to search for
+ * @return true if word exists in dictionary, false otherwise
+ */
+bool bin_compressed_contains(BinCompressedHandle handle, const char* word);
+
+/**
+ * Lookup a word and return results as a JSON string.
+ *
+ * Returns a JSON array of BinEntry objects:
+ * [
+ *   {"stofn": "...", "utg": 123, "ofl": "...", "fl": "...", "ordmynd": "...", "beyging": "..."},
+ *   ...
+ * ]
+ *
+ * @param handle Handle returned by bin_compressed_init()
+ * @param word Latin-1 encoded word to search for
+ * @param cat Optional word category filter (NULL for no filter)
+ * @param lemma Optional lemma filter (NULL for no filter)
+ * @param utg Optional BÍN ID filter (-1 for no filter)
+ * @return JSON string (must be freed with bin_compressed_free_string), or NULL if not found
+ */
+char* bin_compressed_lookup(
+    BinCompressedHandle handle,
+    const char* word,
+    const char* cat,
+    const char* lemma,
+    int utg
+);
+
+/**
+ * Free a string returned by bin_compressed functions.
+ *
+ * @param str String to free (may be NULL)
+ */
+void bin_compressed_free_string(char* str);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/islenska/bincompress.h
+++ b/src/islenska/bincompress.h
@@ -138,6 +138,21 @@ char* bin_compressed_lookup_ksnid(
 char* bin_compressed_lemma_forms(BcHandle handle, int bin_id);
 
 /**
+ * Get all Ksnid entries for a given BÍN ID.
+ *
+ * Returns a JSON array of Ksnid objects for all word forms of the lemma:
+ * [
+ *   {"ord": "...", "bin_id": 123, "ofl": "...", "hluti": "...", "form": "...", "mark": "...", "ksnid": "..."},
+ *   ...
+ * ]
+ *
+ * @param handle Handle returned by bin_compressed_init()
+ * @param bin_id BÍN ID number
+ * @return JSON string (must be freed with bin_compressed_free_string), or NULL if not found
+ */
+char* bin_compressed_lookup_id(BcHandle handle, int bin_id);
+
+/**
  * Free a string returned by bin_compressed functions.
  *
  * @param str String to free (may be NULL)

--- a/src/islenska/bincompress.py
+++ b/src/islenska/bincompress.py
@@ -64,7 +64,6 @@
 
 from typing import (
     Any,
-    AnyStr,
     FrozenSet,
     Iterable,
     Set,
@@ -230,7 +229,7 @@ class BinCompressedPure:
         b = bytes(self._b[p : p + lw])
         return b.decode("latin-1"), self._subcats[cix]  # stofn, fl
 
-    def lemma_forms(self, bin_id: int) -> List[bytes]:
+    def lemma_forms(self, bin_id: int) -> List[str]:
         """Return all word forms that are associated with the lemma
         whose bin_id is given"""
 
@@ -288,29 +287,28 @@ class BinCompressedPure:
         lemma = bytes(self._b[p + 1 : p + 1 + lw])
         if bits & 0x80000000 == 0:
             # No templates associated with this lemma
-            return [lemma]
+            return [lemma.decode("latin-1")]
         lw += 1
         if lw & 3:
             lw += 4 - (lw & 3)
         p += lw
-        # Return all inflection forms as well as the lemma itself
-        result = read_set(self._UINT(p), base=lemma)
-        result.append(lemma)
-        return result
+        # Return all inflection forms as well as the lemma itself, decoded to strings
+        result_bytes = read_set(self._UINT(p), base=lemma)
+        result_bytes.append(lemma)
+        return [form.decode("latin-1") for form in result_bytes]
 
-    def _mapping_cffi(self, word: Union[str, bytes]) -> Optional[int]:
+    def _mapping_cffi(self, word: str) -> Optional[int]:
         """Call the C++ mapping() function that has been wrapped using CFFI"""
         try:
-            if isinstance(word, str):
-                word = word.encode("latin-1")
-            m: int = bin_cffi.mapping(self._mmap_ptr, word)
+            word_bytes = word.encode("latin-1")
+            m: int = bin_cffi.mapping(self._mmap_ptr, word_bytes)
             return None if m == 0xFFFFFFFF else m
         except UnicodeEncodeError:
             # The word contains a non-latin-1 character:
             # it can't be in the trie
             return None
 
-    def _raw_lookup(self, word: AnyStr) -> List[Tuple[int, int, int]]:
+    def _raw_lookup(self, word: str) -> List[Tuple[int, int, int]]:
         """Return a list of lemma/meaning/ksnid tuples for the word, or
         an empty list if it is not found in the trie"""
         mapping = self._mapping_cffi(word)
@@ -544,9 +542,7 @@ class BinCompressedPure:
             # Go through the variants of this
             # lemma, for the requested case
             wanted_beyging = simplify_beyging(beyging)
-            for c_latin in self.lemma_forms(bin_id):
-                # TODO: Encoding and decoding back and forth is not terribly efficient
-                c = c_latin.decode("latin-1")
+            for c in self.lemma_forms(bin_id):
                 # Make sure we only include each result once.
                 # Also note that we need to check again for the word
                 # category constraint because different inflection
@@ -570,8 +566,8 @@ class BinCompressedPure:
         forms = self.lemma_forms(bin_id)
         if forms:
             stofn, fl = self.lemma(bin_id)
-            for form_latin in forms:
-                for form_id, mix, kix in self._raw_lookup(form_latin):
+            for form in forms:
+                for form_id, mix, kix in self._raw_lookup(form):
                     if form_id != bin_id:
                         continue
                     # Found a word form of the same lemma
@@ -583,7 +579,7 @@ class BinCompressedPure:
                             bin_id,
                             ofl,
                             fl,
-                            form_latin.decode("latin-1"),
+                            form,
                             beyging,
                             ksnid_string,
                         )
@@ -640,8 +636,8 @@ class BinCompressedPure:
                 # The user-defined filter fails
                 continue
             b_set.update(mark_to_set(beyging))
-            for form_latin in self.lemma_forms(bin_id):
-                for form_id, mix, kix in self._raw_lookup(form_latin):
+            for form in self.lemma_forms(bin_id):
+                for form_id, mix, kix in self._raw_lookup(form):
                     if form_id != bin_id:
                         continue
                     # Found a word form of the same lemma
@@ -661,7 +657,7 @@ class BinCompressedPure:
                             bin_id,
                             ofl,
                             fl,
-                            form_latin.decode("latin-1"),
+                            form,
                             this_beyging,
                             ksnid_string,
                         )
@@ -682,8 +678,7 @@ class BinCompressedPure:
         Note that the word form is case-sensitive."""
         result: Set[BinEntryTuple] = set()
         for lemma_index, _, _ in self._raw_lookup(word):
-            for c_latin in self.lemma_forms(lemma_index):
-                c = c_latin.decode("latin-1")
+            for c in self.lemma_forms(lemma_index):
                 # Make sure we only include each result once
                 result.update(m for m in self.lookup(c) if "NF" in m[5])
         return result
@@ -883,6 +878,25 @@ class BinCompressed(BinCompressedPure):
         except UnicodeEncodeError:
             # Word contains non-Latin-1 characters, can't be in dictionary
             return []
+
+    def lemma_forms(self, bin_id: int) -> List[str]:
+        """Get all word forms for a lemma (C++ implementation).
+
+        Returns all inflected forms of the lemma identified by bin_id,
+        decompressed from the templates section.
+        """
+        result_ptr = bin_cffi.bin_compressed_lemma_forms(self._cpp_handle, bin_id)
+
+        if not result_ptr:
+            return []
+
+        try:
+            result_bytes = ffi.string(result_ptr)
+            forms_utf8 = json.loads(result_bytes)
+            # Return the UTF-8 decoded strings directly
+            return forms_utf8
+        finally:
+            bin_cffi.bin_compressed_free_string(result_ptr)
 
     # Other methods (lookup_variants, lookup_case,
     # lookup_id, raw_nominative, nominative, accusative, dative, genitive, etc.)

--- a/src/islenska/bincompress.py
+++ b/src/islenska/bincompress.py
@@ -232,6 +232,55 @@ class BinCompressedPure:
         b = bytes(self._b[p : p + lw])
         return b.decode("latin-1"), self._subcats[cix]  # stofn, fl
 
+    # Abstract methods that must be overridden in BinCompressed
+    # These are called by methods in this base class but implemented in C++
+
+    def contains(self, word: str) -> bool:
+        """Check if word exists in dictionary - must be implemented in subclass"""
+        raise NotImplementedError(
+            "BinCompressedPure.contains() must be overridden in BinCompressed"
+        )
+
+    __contains__ = contains
+
+    def lookup(
+        self,
+        word: str,
+        cat: Optional[str] = None,
+        lemma: Optional[str] = None,
+        utg: Optional[int] = None,
+        inflection_filter: Optional[InflectionFilter] = None,
+    ) -> List[BinEntryTuple]:
+        """Lookup word in dictionary - must be implemented in subclass"""
+        raise NotImplementedError(
+            "BinCompressedPure.lookup() must be overridden in BinCompressed"
+        )
+
+    def lookup_ksnid(
+        self,
+        word: str,
+        cat: Optional[str] = None,
+        lemma: Optional[str] = None,
+        utg: Optional[int] = None,
+        inflection_filter: Optional[InflectionFilter] = None,
+    ) -> List[Ksnid]:
+        """Lookup word and return Ksnid entries - must be implemented in subclass"""
+        raise NotImplementedError(
+            "BinCompressedPure.lookup_ksnid() must be overridden in BinCompressed"
+        )
+
+    def lemma_forms(self, bin_id: int) -> List[str]:
+        """Get all word forms for a lemma - must be implemented in subclass"""
+        raise NotImplementedError(
+            "BinCompressedPure.lemma_forms() must be overridden in BinCompressed"
+        )
+
+    def lookup_id(self, bin_id: int) -> List[Ksnid]:
+        """Get all Ksnid entries for a BÍN ID - must be implemented in subclass"""
+        raise NotImplementedError(
+            "BinCompressedPure.lookup_id() must be overridden in BinCompressed"
+        )
+
     def _mapping_cffi(self, word: str) -> Optional[int]:
         """Call the C++ mapping() function that has been wrapped using CFFI"""
         try:

--- a/src/islenska/bincompress.py
+++ b/src/islenska/bincompress.py
@@ -110,10 +110,13 @@ from .basics import (
 
 
 class BinCompressedPure:
-    """Pure Python implementation of the compressed binary dictionary.
+    """Base class for the compressed binary dictionary.
 
-    This class is kept as a reference implementation and fallback.
-    The BinCompressed class below uses C++ for performance where available.
+    This class provides the Python infrastructure and methods that haven't
+    been migrated to C++. The BinCompressed class inherits from this and
+    overrides key methods with optimized C++ implementations.
+
+    Note: Do not instantiate this class directly. Use BinCompressed instead.
     """
 
     # Note: the resource path below should NOT use os.path.join()
@@ -229,74 +232,6 @@ class BinCompressedPure:
         b = bytes(self._b[p : p + lw])
         return b.decode("latin-1"), self._subcats[cix]  # stofn, fl
 
-    def lemma_forms(self, bin_id: int) -> List[str]:
-        """Return all word forms that are associated with the lemma
-        whose bin_id is given"""
-
-        def read_set(p: int, base: bytes) -> List[bytes]:
-            """Decompress a set of strings compressed by compress_set()"""
-            b = self._templates
-            c: List[bytes] = []
-            last_w = base
-            lw = len(last_w)
-            while True:
-                # How many letters should we cut off the end of the
-                # last word before appending the divergent part?
-                cut = b[p]
-                p += 1
-                if cut == 0x00:
-                    # Done
-                    break
-                if cut & 0x80:
-                    # Long form: the cut is in the lower 7 bits and the
-                    # length is in the following byte
-                    cut &= 0x7F
-                    lw_new = b[p]
-                    p += 1
-                else:
-                    # The cut is in the upper 4 bits, and (len - cut) in the lower 3
-                    diff = (cut & 0x03) - (cut & 0x04)
-                    cut >>= 3
-                    lw_new = cut + diff
-                # Calculate the number of common characters between
-                # this word and the last one
-                common = lw - cut
-                lw = lw_new
-                # Assemble this word and append it to our result
-                w = last_w[0:common] + b[p : p + lw]
-                p += lw
-                c.append(w)
-                last_w = w
-                lw += common
-            # Return the set as a list of byte strings
-            return c
-
-        # Sanity check on the BÍN id
-        if not 0 <= bin_id <= self._max_bin_id:
-            return []
-        off: int
-        (off,) = UINT32.unpack_from(self._lemmas, bin_id * 4)
-        if off == 0:
-            # No entry with this BÍN id
-            return []
-        bits = self._UINT(off)
-        # Skip past the lemma itself
-        assert self._b is not None
-        p = off + 4
-        lw = self._b[p]  # Length byte
-        lemma = bytes(self._b[p + 1 : p + 1 + lw])
-        if bits & 0x80000000 == 0:
-            # No templates associated with this lemma
-            return [lemma.decode("latin-1")]
-        lw += 1
-        if lw & 3:
-            lw += 4 - (lw & 3)
-        p += lw
-        # Return all inflection forms as well as the lemma itself, decoded to strings
-        result_bytes = read_set(self._UINT(p), base=lemma)
-        result_bytes.append(lemma)
-        return [form.decode("latin-1") for form in result_bytes]
-
     def _mapping_cffi(self, word: str) -> Optional[int]:
         """Call the C++ mapping() function that has been wrapped using CFFI"""
         try:
@@ -345,104 +280,6 @@ class BinCompressedPure:
             if w0 & 0x80000000:
                 # Last mapping indicator: we're done
                 break
-        return result
-
-    def contains(self, word: str) -> bool:
-        """Returns True if the trie contains the given word form"""
-        return self._mapping_cffi(word) is not None
-
-    __contains__ = contains
-
-    def lookup(
-        self,
-        word: str,
-        cat: Optional[str] = None,
-        lemma: Optional[str] = None,
-        utg: Optional[int] = None,
-        inflection_filter: Optional[InflectionFilter] = None,
-    ) -> List[BinEntryTuple]:
-        """Returns a list of BÍN entries for the given word form,
-        eventually constrained to the requested word category,
-        lemma, utg number and/or the given beyging_func filter function,
-        which is called with the beyging field as a parameter."""
-
-        # Category set
-        if cat is None:
-            cats = None
-        elif cat == "no":
-            # Allow a cat of "no" to mean a noun of any gender
-            cats = ALL_GENDERS
-        else:
-            cats = frozenset([cat])
-        result: List[BinEntryTuple] = []
-        for bin_id, meaning_index, _ in self._raw_lookup(word):
-            if utg is not None and bin_id != utg:
-                # Fails the utg filter
-                continue
-            ofl, beyging = self.meaning(meaning_index)
-            if cats is not None and ofl not in cats:
-                # Fails the word category constraint
-                continue
-            stofn, fl = self.lemma(bin_id)
-            if lemma is not None and stofn != lemma:
-                # Fails the lemma filter
-                continue
-            if inflection_filter is not None and not inflection_filter(beyging):
-                # Fails the beyging_func filter
-                continue
-            # stofn, utg, ofl, fl, ordmynd, beyging
-            result.append((stofn, bin_id, ofl, fl, word, beyging))
-        return result
-
-    def lookup_ksnid(
-        self,
-        word: str,
-        cat: Optional[str] = None,
-        lemma: Optional[str] = None,
-        utg: Optional[int] = None,
-        inflection_filter: Optional[InflectionFilter] = None,
-    ) -> List[Ksnid]:
-        """Returns a list of BÍN entries for the given word form,
-        eventually constrained to the requested word category,
-        lemma, utg number and/or the given beyging_func filter function,
-        which is called with the beyging field as a parameter."""
-
-        # Category set
-        if cat is None:
-            cats = None
-        elif cat == "no":
-            # Allow a cat of "no" to mean a noun of any gender
-            cats = ALL_GENDERS
-        else:
-            cats = frozenset([cat])
-        result: List[Ksnid] = []
-        for bin_id, meaning_index, ksnid_index in self._raw_lookup(word):
-            if utg is not None and bin_id != utg:
-                # Fails the utg filter
-                continue
-            ofl, beyging = self.meaning(meaning_index)
-            if cats is not None and ofl not in cats:
-                # Fails the word category constraint
-                continue
-            stofn, fl = self.lemma(bin_id)
-            if lemma is not None and stofn != lemma:
-                # Fails the lemma filter
-                continue
-            if inflection_filter is not None and not inflection_filter(beyging):
-                # Fails the beyging_func filter
-                continue
-            ksnid_string = self.ksnid_string(ksnid_index)
-            result.append(
-                Ksnid.from_parameters(
-                    stofn,
-                    bin_id,
-                    ofl,
-                    fl,
-                    word,
-                    beyging,
-                    ksnid_string,
-                )
-            )
         return result
 
     def lookup_case(
@@ -559,32 +396,6 @@ class BinCompressedPure:
                     )
                 )
         return result
-
-    def lookup_id(self, bin_id: int) -> List[Ksnid]:
-        """Given a BÍN id number, return a set of matching Ksnid entries"""
-        result: Set[Ksnid] = set()
-        forms = self.lemma_forms(bin_id)
-        if forms:
-            stofn, fl = self.lemma(bin_id)
-            for form in forms:
-                for form_id, mix, kix in self._raw_lookup(form):
-                    if form_id != bin_id:
-                        continue
-                    # Found a word form of the same lemma
-                    ofl, beyging = self.meaning(mix)
-                    ksnid_string = self.ksnid_string(kix)
-                    result.add(
-                        Ksnid.from_parameters(
-                            stofn,
-                            bin_id,
-                            ofl,
-                            fl,
-                            form,
-                            beyging,
-                            ksnid_string,
-                        )
-                    )
-        return list(result)
 
     def lookup_variants(
         self,

--- a/src/islenska/bincompress.py
+++ b/src/islenska/bincompress.py
@@ -818,7 +818,73 @@ class BinCompressed(BinCompressedPure):
             # Word contains non-Latin-1 characters, can't be in dictionary
             return []
 
-    # Other methods (lookup_variants, lookup_ksnid, lookup_case,
+    def lookup_ksnid(
+        self,
+        word: str,
+        cat: Optional[str] = None,
+        lemma: Optional[str] = None,
+        utg: Optional[int] = None,
+        inflection_filter: Optional[InflectionFilter] = None,
+    ) -> List[Ksnid]:
+        """Lookup word and return Ksnid entries (C++ implementation with Python fallback for filters).
+
+        Overrides base class method with optimized C++ version.
+        The C++ implementation handles cat, lemma, and utg filters.
+        If inflection_filter is provided, we apply it to the C++ results.
+        """
+        try:
+            word_bytes = word.encode("latin-1")
+
+            # Prepare filter parameters for C++
+            # CFFI requires ffi.NULL instead of None for null pointers
+            cat_bytes = cat.encode("latin-1") if cat else ffi.NULL
+            lemma_bytes = lemma.encode("latin-1") if lemma else ffi.NULL
+            utg_value = utg if utg is not None else -1
+
+            # Call C++ lookup_ksnid
+            result_ptr = bin_cffi.bin_compressed_lookup_ksnid(
+                self._cpp_handle,
+                word_bytes,
+                cat_bytes,
+                lemma_bytes,
+                utg_value
+            )
+
+            if not result_ptr:
+                return []
+
+            try:
+                # Parse JSON result (C++ returns UTF-8 bytes)
+                result_bytes = ffi.string(result_ptr)
+                entries = json.loads(result_bytes)
+
+                # Convert to Ksnid objects
+                result: List[Ksnid] = []
+                for entry in entries:
+                    # Apply inflection_filter if provided
+                    if inflection_filter is not None and not inflection_filter(entry["mark"]):
+                        continue
+
+                    ksnid_obj = Ksnid.from_parameters(
+                        entry["ord"],
+                        entry["bin_id"],
+                        entry["ofl"],
+                        entry["hluti"],
+                        entry["form"],
+                        entry["mark"],
+                        entry["ksnid"]
+                    )
+                    result.append(ksnid_obj)
+
+                return result
+            finally:
+                bin_cffi.bin_compressed_free_string(result_ptr)
+
+        except UnicodeEncodeError:
+            # Word contains non-Latin-1 characters, can't be in dictionary
+            return []
+
+    # Other methods (lookup_variants, lookup_case,
     # lookup_id, raw_nominative, nominative, accusative, dative, genitive, etc.)
     # are inherited from BinCompressedPure and will be gradually migrated to C++
     # by adding overrides here as implementations become available.

--- a/src/islenska/bincompress.py
+++ b/src/islenska/bincompress.py
@@ -898,7 +898,41 @@ class BinCompressed(BinCompressedPure):
         finally:
             bin_cffi.bin_compressed_free_string(result_ptr)
 
+    def lookup_id(self, bin_id: int) -> List[Ksnid]:
+        """Get all Ksnid entries for a given BÍN ID (C++ implementation).
+
+        Overrides base class method with optimized C++ version.
+        Returns all word forms of the lemma with their full Ksnid information.
+        """
+        result_ptr = bin_cffi.bin_compressed_lookup_id(self._cpp_handle, bin_id)
+
+        if not result_ptr:
+            return []
+
+        try:
+            # Parse JSON result (C++ returns UTF-8 bytes)
+            result_bytes = ffi.string(result_ptr)
+            entries = json.loads(result_bytes)
+
+            # Convert to Ksnid objects
+            result: List[Ksnid] = []
+            for entry in entries:
+                ksnid_obj = Ksnid.from_parameters(
+                    entry["ord"],
+                    entry["bin_id"],
+                    entry["ofl"],
+                    entry["hluti"],
+                    entry["form"],
+                    entry["mark"],
+                    entry["ksnid"]
+                )
+                result.append(ksnid_obj)
+
+            return result
+        finally:
+            bin_cffi.bin_compressed_free_string(result_ptr)
+
     # Other methods (lookup_variants, lookup_case,
-    # lookup_id, raw_nominative, nominative, accusative, dative, genitive, etc.)
+    # raw_nominative, nominative, accusative, dative, genitive, etc.)
     # are inherited from BinCompressedPure and will be gradually migrated to C++
     # by adding overrides here as implementations become available.

--- a/src/islenska/bincompress.py
+++ b/src/islenska/bincompress.py
@@ -78,7 +78,7 @@ from typing import (
 import struct
 import functools
 import mmap
-
+import json
 import importlib.resources as importlib_resources
 
 # Import the CFFI wrapper for the bin.cpp C++ module (see also build_bin.py)
@@ -110,9 +110,12 @@ from .basics import (
 )
 
 
-class BinCompressed:
-    """A wrapper for the compressed binary dictionary,
-    allowing read-only lookups of word forms"""
+class BinCompressedPure:
+    """Pure Python implementation of the compressed binary dictionary.
+
+    This class is kept as a reference implementation and fallback.
+    The BinCompressed class below uses C++ for performance where available.
+    """
 
     # Note: the resource path below should NOT use os.path.join()
     ref = importlib_resources.files("islenska") / "resources" / BIN_COMPRESSED_FILE
@@ -708,3 +711,114 @@ class BinCompressed:
         subject to the given constraints on the beyging field.
         Note that the word form is case-sensitive."""
         return self.lookup_case(word, "EF", **options)
+
+
+class BinCompressed(BinCompressedPure):
+    """Hybrid Python/C++ wrapper for the compressed binary dictionary.
+
+    Inherits from BinCompressedPure and overrides methods with C++ implementations
+    for improved performance. Methods not yet migrated to C++ are inherited from
+    the base class.
+
+    The base class creates the memory-mapped file, which is shared with the C++
+    implementation to avoid duplication.
+    """
+
+    def __init__(self) -> None:
+        """Initialize base class and add C++ handle for optimized methods."""
+        # Initialize base class (creates mmap, sets up all Python infrastructure)
+        super().__init__()
+
+        # Initialize C++ handle using the mmap from base class
+        self._cpp_handle = bin_cffi.bin_compressed_init(ffi.from_buffer(self._b))
+        if not self._cpp_handle:
+            raise RuntimeError("Failed to initialize C++ BinCompressed handle")
+
+    def __del__(self) -> None:
+        """Clean up C++ resources."""
+        if hasattr(self, '_cpp_handle') and self._cpp_handle:
+            bin_cffi.bin_compressed_close(self._cpp_handle)
+
+    # Override methods with C++ implementations
+    def contains(self, word: str) -> bool:
+        """Check if word exists in dictionary (C++ implementation).
+
+        Overrides base class method with optimized C++ version.
+        """
+        try:
+            word_bytes = word.encode("latin-1")
+            return bin_cffi.bin_compressed_contains(self._cpp_handle, word_bytes)
+        except UnicodeEncodeError:
+            # Word contains non-Latin-1 characters, can't be in dictionary
+            return False
+
+    __contains__ = contains
+
+    def lookup(
+        self,
+        word: str,
+        cat: Optional[str] = None,
+        lemma: Optional[str] = None,
+        utg: Optional[int] = None,
+        inflection_filter: Optional[InflectionFilter] = None,
+    ) -> List[BinEntryTuple]:
+        """Lookup word in dictionary (C++ implementation with Python fallback for filters).
+
+        Overrides base class method with optimized C++ version.
+        The C++ implementation handles cat, lemma, and utg filters.
+        If inflection_filter is provided, we fall back to Python filtering.
+        """
+        try:
+            word_bytes = word.encode("latin-1")
+
+            # Prepare filter parameters for C++
+            # CFFI requires ffi.NULL instead of None for null pointers
+            cat_bytes = cat.encode("latin-1") if cat else ffi.NULL
+            lemma_bytes = lemma.encode("latin-1") if lemma else ffi.NULL
+            utg_value = utg if utg is not None else -1
+
+            # Call C++ lookup
+            result_ptr = bin_cffi.bin_compressed_lookup(
+                self._cpp_handle,
+                word_bytes,
+                cat_bytes,
+                lemma_bytes,
+                utg_value
+            )
+
+            if not result_ptr:
+                return []
+
+            try:
+                # Parse JSON result (C++ now returns UTF-8 bytes)
+                result_bytes = ffi.string(result_ptr)
+                entries = json.loads(result_bytes)  # json.loads accepts UTF-8 bytes
+
+                # Convert to BinEntryTuple format: (stofn, utg, ofl, fl, ordmynd, beyging)
+                result: List[BinEntryTuple] = []
+                for entry in entries:
+                    tuple_entry: BinEntryTuple = (
+                        entry["stofn"],
+                        entry["utg"],
+                        entry["ofl"],
+                        entry["fl"],
+                        entry["ordmynd"],
+                        entry["beyging"]
+                    )
+
+                    # Apply inflection_filter if provided
+                    if inflection_filter is None or inflection_filter(tuple_entry[5]):
+                        result.append(tuple_entry)
+
+                return result
+            finally:
+                bin_cffi.bin_compressed_free_string(result_ptr)
+
+        except UnicodeEncodeError:
+            # Word contains non-Latin-1 characters, can't be in dictionary
+            return []
+
+    # Other methods (lookup_variants, lookup_ksnid, lookup_case,
+    # lookup_id, raw_nominative, nominative, accusative, dative, genitive, etc.)
+    # are inherited from BinCompressedPure and will be gradually migrated to C++
+    # by adding overrides here as implementations become available.

--- a/src/islenska/bincompress.py
+++ b/src/islenska/bincompress.py
@@ -591,7 +591,7 @@ class BinCompressed(BinCompressedPure):
 
     def __del__(self) -> None:
         """Clean up C++ resources."""
-        if hasattr(self, '_cpp_handle') and self._cpp_handle:
+        if self._cpp_handle:
             bin_cffi.bin_compressed_close(self._cpp_handle)
 
     # Override methods with C++ implementations

--- a/src/islenska/dawgdictionary.cpp
+++ b/src/islenska/dawgdictionary.cpp
@@ -144,9 +144,6 @@ class PackedNavigation;
  * it to Latin-1 for processing since all Icelandic characters fit within
  * Latin-1 (ISO-8859-1). This simplifies string handling in C++.
  *
- * IMPORTANT: We must use a byte array with explicit length rather than
- * std::string to correctly handle any embedded null bytes in the vocabulary.
- *
  * @param utf8_bytes  Pointer to UTF-8 encoded byte array
  * @param utf8_len    Length of the UTF-8 byte array
  * @return Latin-1 encoded string with the same character content
@@ -155,17 +152,17 @@ class PackedNavigation;
  *       3-byte and 4-byte sequences are replaced with '?' but should
  *       not occur in Icelandic vocabulary per project guarantees.
  */
-std::string utf8_to_latin1(const char* utf8_bytes, size_t utf8_len) {
+std::string utf8_to_latin1(const BYTE* utf8_bytes, size_t utf8_len) {
     std::string latin1_str;
     latin1_str.reserve(utf8_len);
     for (size_t i = 0; i < utf8_len; ) {
-        unsigned char c = utf8_bytes[i];
+        BYTE c = utf8_bytes[i];
         if (c < 0x80) { // Standard ASCII (including null byte!)
             latin1_str += c;
             i += 1;
         } else if ((c & 0xE0) == 0xC0) { // 2-byte UTF-8 sequence
             if (i + 1 < utf8_len) {
-                int codepoint = ((c & 0x1F) << 6) | (utf8_bytes[i + 1] & 0x3F);
+                size_t codepoint = ((c & 0x1F) << 6) | (utf8_bytes[i + 1] & 0x3F);
                 latin1_str += (char)(codepoint > 255 ? '?' : codepoint);
                 i += 2;
             } else {
@@ -362,7 +359,7 @@ private:
     // Encoding map: byte code -> character string
     // Maps vocabulary indices (0, 1, 2, ...) to their characters.
     // Also maps (index | 0x80) to character with '|' suffix for finality.
-    std::map<int, std::string> m_encoding;
+    std::map<BYTE, std::string> m_encoding;
 
     // Cache of parsed nodes: node_offset -> (prefix -> next_node_offset)
     // Avoids re-parsing the same node multiple times during navigation.
@@ -455,23 +452,24 @@ CompoundNavigator::CompoundNavigator(DAWG_Dictionary* dawg, const std::string& w
  * @param final   True if matched is a complete word in the dictionary
  */
 void CompoundNavigator::accept(const std::string& matched, bool final) {
-    if (final) {
-        if (m_index == m_len) {
-            // We've consumed the entire input word - single part solution
-            m_parts.push_back({matched});
-        } else {
-            // There's more to match - recursively split the remainder
-            std::string remainder = m_word.substr(m_index);
-            CompoundNavigator nav(m_dawg, remainder);
-            m_dawg->navigate(nav);
-            std::vector<std::vector<std::string>> result = nav.result();
-            if (!result.empty()) {
-                // For each way to split the remainder, prepend our matched part
-                for (const auto& tail : result) {
-                    std::vector<std::string> combination = {matched};
-                    combination.insert(combination.end(), tail.begin(), tail.end());
-                    m_parts.push_back(combination);
-                }
+    if (!final) {
+        return; // Only proceed if we have a complete word
+    }
+    if (m_index == m_len) {
+        // We've consumed the entire input word - single part solution
+        m_parts.push_back({matched});
+    } else {
+        // There's more to match - recursively split the remainder
+        std::string remainder = m_word.substr(m_index);
+        CompoundNavigator nav(m_dawg, remainder);
+        m_dawg->navigate(nav);
+        std::vector<std::vector<std::string>> result = nav.result();
+        if (!result.empty()) {
+            // For each way to split the remainder, prepend our matched part
+            for (const auto& tail : result) {
+                std::vector<std::string> combination = {matched};
+                combination.insert(combination.end(), tail.begin(), tail.end());
+                m_parts.push_back(combination);
             }
         }
     }
@@ -515,7 +513,7 @@ DAWG_Dictionary::DAWG_Dictionary(const BYTE* pbMap) : m_pbMap(pbMap) {
     UINT32 len_voc = *(UINT32*)(m_pbMap + 12);
 
     // Vocabulary starts at byte 16
-    const char* voc_bytes = (const char*)(m_pbMap + 16);
+    const BYTE* voc_bytes = m_pbMap + 16;
 
     // Graph data starts immediately after vocabulary
     m_root_offset = 16 + len_voc;

--- a/src/islenska/dawgdictionary.cpp
+++ b/src/islenska/dawgdictionary.cpp
@@ -157,7 +157,7 @@ std::string utf8_to_latin1(const BYTE* utf8_bytes, size_t utf8_len) {
     latin1_str.reserve(utf8_len);
     for (size_t i = 0; i < utf8_len; ) {
         BYTE c = utf8_bytes[i];
-        if (c < 0x80) { // Standard ASCII (including null byte!)
+        if (c < 0x80) { // Standard ASCII
             latin1_str += c;
             i += 1;
         } else if ((c & 0xE0) == 0xC0) { // 2-byte UTF-8 sequence

--- a/src/islenska/dawgdictionary.cpp
+++ b/src/islenska/dawgdictionary.cpp
@@ -1,0 +1,861 @@
+/*
+
+   BinPackage
+
+   C++ DAWG dictionary module
+
+   Copyright © 2025 Miðeind ehf.
+   Original author: Vilhjálmur Þorsteinsson
+
+   This software is licensed under the MIT License:
+
+      Permission is hereby granted, free of charge, to any person
+      obtaining a copy of this software and associated documentation
+      files (the "Software"), to deal in the Software without restriction,
+      including without limitation the rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the Software,
+      and to permit persons to whom the Software is furnished to do so,
+      subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be
+      included in all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   --------------------------------------------------------------------------
+
+   This module implements a C++ interface to packed DAWG (Directed Acyclic
+   Word Graph) dictionaries for efficient storage and lookup of Icelandic
+   word forms, primarily for compound word analysis.
+
+   DAWG STRUCTURE:
+
+   A DAWG is a trie-like data structure where common suffixes are merged,
+   resulting in a directed acyclic graph. This provides both space efficiency
+   (shared storage of common word parts) and time efficiency (fast lookups).
+
+   BINARY FILE FORMAT:
+
+   The binary DAWG file uses a custom packed format:
+
+   [Header - 12 bytes]
+     - Signature: "ReynirDawg!\n" (12 bytes)
+
+   [Vocabulary section]
+     - Length: 4-byte little-endian uint32 (number of UTF-8 bytes)
+     - Data: UTF-8 encoded string of all unique characters in the vocabulary
+
+   [Graph section - starts at offset (16 + vocabulary_length)]
+     - Root node followed by all other nodes in the graph
+
+   NODE FORMAT:
+
+   Each node consists of:
+     - Header byte: Lower 7 bits = number of outgoing edges
+                   (High bit is reserved/unused at node level)
+     - Series of edges (described below)
+
+   EDGE FORMAT:
+
+   Each edge from a node consists of:
+     - Length byte: Lower 7 bits = number of character codes in prefix
+                   (High bit reserved/unused at edge level)
+     - Prefix bytes: Array of vocabulary indices (character codes)
+       * Each byte is an index into the vocabulary string
+       * High bit (0x80) on a byte indicates "final" marker (see below)
+       * The encoding map converts these indices to actual characters
+     - Next node offset (optional): 4-byte little-endian uint32
+       * Only present if the last prefix byte does NOT have the 0x80 bit set
+       * If 0x80 bit is set on last byte, the edge terminates (nextnode = 0)
+
+   FINALITY MARKER:
+
+   The 0x80 (128) bit on the LAST byte of an edge prefix indicates that
+   the word formed by following the path up to (and including) that character
+   is a complete, valid word in the dictionary. This allows a single edge to
+   encode multiple word boundaries. For example:
+
+     - Edge with prefix "ing" where 'g' has 0x80 bit set:
+       The word ending in 'g' is final (complete word).
+     - Edge with prefix "ings" where only 's' has 0x80 bit set:
+       The word ending in 's' is final, but 'ing' is not.
+
+   The encoding map stores two versions of each character:
+     - Index i: The character itself (e.g., 'a')
+     - Index i|0x80: The character with a pipe suffix (e.g., 'a|')
+
+   The pipe character '|' in the decoded prefix indicates a finality point.
+
+   ENCODING:
+
+   Characters in the vocabulary are stored as UTF-8 bytes in the file, but
+   converted to Latin-1 (ISO-8859-1) strings during processing. The Icelandic
+   alphabet fits entirely within Latin-1, so no information is lost.
+
+   Each character is assigned an index (0, 1, 2, ...) based on its position
+   in the vocabulary. The DAWG uses these indices (not the actual character
+   codes) to represent characters in edges. This allows for compact storage
+   when the vocabulary is small (< 128 characters, since we need 1 bit for
+   the finality marker).
+
+   NAVIGATION:
+
+   Navigating the DAWG involves following edges from the root node while
+   matching characters from the input word. The Navigator pattern is used
+   to control the navigation logic:
+
+     - FindNavigator: Simple word lookup (does word exist in DAWG?)
+     - CompoundNavigator: Recursive compound word splitting
+
+   The navigation caches decoded edges in m_iter_cache to avoid repeated
+   parsing of the same nodes.
+
+*/
+
+#include <string>
+#include <vector>
+#include <map>
+#include <sstream>
+#include <cstring>
+#include <algorithm>
+#include <stdexcept>
+
+#include "dawgdictionary.h"
+
+#define TRUE 1
+#define FALSE 0
+
+typedef uint32_t UINT32;
+
+// Forward declarations
+class DAWG_Dictionary;
+class PackedNavigation;
+
+/**
+ * Convert a UTF-8 byte array to a Latin-1 (ISO-8859-1) string.
+ *
+ * The DAWG vocabulary is stored as UTF-8 in the binary file, but we convert
+ * it to Latin-1 for processing since all Icelandic characters fit within
+ * Latin-1 (ISO-8859-1). This simplifies string handling in C++.
+ *
+ * IMPORTANT: We must use a byte array with explicit length rather than
+ * std::string to correctly handle any embedded null bytes in the vocabulary.
+ *
+ * @param utf8_bytes  Pointer to UTF-8 encoded byte array
+ * @param utf8_len    Length of the UTF-8 byte array
+ * @return Latin-1 encoded string with the same character content
+ *
+ * @note Only handles single-byte (ASCII) and 2-byte UTF-8 sequences.
+ *       3-byte and 4-byte sequences are replaced with '?' but should
+ *       not occur in Icelandic vocabulary per project guarantees.
+ */
+std::string utf8_to_latin1(const char* utf8_bytes, size_t utf8_len) {
+    std::string latin1_str;
+    latin1_str.reserve(utf8_len);
+    for (size_t i = 0; i < utf8_len; ) {
+        unsigned char c = utf8_bytes[i];
+        if (c < 0x80) { // Standard ASCII (including null byte!)
+            latin1_str += c;
+            i += 1;
+        } else if ((c & 0xE0) == 0xC0) { // 2-byte UTF-8 sequence
+            if (i + 1 < utf8_len) {
+                int codepoint = ((c & 0x1F) << 6) | (utf8_bytes[i + 1] & 0x3F);
+                latin1_str += (char)(codepoint > 255 ? '?' : codepoint);
+                i += 2;
+            } else {
+                latin1_str += '?'; // Malformed
+                i += 1;
+            }
+        } else {
+            // Per project guarantees, we don't expect 3- or 4-byte sequences
+            latin1_str += '?'; // Malformed or unexpected
+            i += 1;
+        }
+    }
+    return latin1_str;
+}
+
+/**
+ * Abstract base class for DAWG navigation strategies.
+ *
+ * The Navigator pattern allows different types of DAWG traversals
+ * (simple lookup, compound word splitting, etc.) to be implemented
+ * by subclassing and providing custom logic for accepting/rejecting
+ * characters and edges during graph traversal.
+ *
+ * The navigation engine (PackedNavigation) calls these methods to
+ * control the traversal:
+ *
+ *   1. push_edge(): Determines if an edge should be explored
+ *   2. accepts(): Determines if a character should be accepted
+ *   3. accept(): Called when a (partial or complete) match is found
+ *   4. pop_edge(): Called after exploring an edge (can short-circuit)
+ *   5. accepting(): Determines if navigation should continue
+ */
+class Navigator {
+public:
+    virtual ~Navigator() {}
+
+    /** Check if an edge starting with firstchar should be explored */
+    virtual bool push_edge(char firstchar) = 0;
+
+    /** Check if the navigator is still accepting more characters */
+    virtual bool accepting() = 0;
+
+    /** Accept a character and advance position. Returns false if char doesn't match */
+    virtual bool accepts(char newchar) = 0;
+
+    /** Called when a match (partial or complete) is found
+     *  @param matched The string matched so far
+     *  @param final   True if this is a complete word (has finality marker)
+     */
+    virtual void accept(const std::string& matched, bool final) = 0;
+
+    /** Called after exploring an edge. Return false to short-circuit navigation */
+    virtual bool pop_edge() = 0;
+};
+
+/**
+ * Navigator for simple word existence checks.
+ *
+ * FindNavigator performs a straightforward lookup: it follows the path
+ * matching the input word character-by-character. If the navigation
+ * reaches the end of the word AND encounters a finality marker, the
+ * word is found.
+ *
+ * This is used by DAWG_Dictionary::contains() for "word in dictionary"
+ * queries.
+ */
+class FindNavigator : public Navigator {
+private:
+    const std::string& m_word;
+    size_t m_len;
+    size_t m_index;
+    bool m_found;
+
+public:
+    FindNavigator(const std::string& word) : m_word(word), m_len(word.length()), m_index(0), m_found(false) {}
+
+    bool push_edge(char firstchar) override {
+        // Only explore edges that match the next character in our word
+        if (m_index >= m_len) return false;
+        return m_word[m_index] == firstchar;
+    }
+
+    bool accepting() override {
+        // Continue while we haven't consumed the entire word
+        return m_index < m_len;
+    }
+
+    bool accepts(char newchar) override {
+        // Accept only if the character matches the next position in word
+        if (m_index >= m_len || newchar != m_word[m_index]) {
+            return false;
+        }
+        m_index++;
+        return true;
+    }
+
+    void accept(const std::string& matched, bool final) override {
+        // Word is found if we've consumed all characters AND hit a final marker
+        if (final && m_index == m_len) {
+            m_found = true;
+        }
+    }
+
+    bool pop_edge() override {
+        // Short-circuit: stop searching once we've explored an edge
+        // (no need to continue since we're doing exact match)
+        return false;
+    }
+
+    bool is_found() const {
+        return m_found;
+    }
+};
+
+/**
+ * Navigator for compound word analysis.
+ *
+ * CompoundNavigator attempts to split an unknown word into valid parts
+ * (compound word decomposition). When it finds a complete word that is
+ * a prefix of the input, it recursively searches for ways to split the
+ * remainder.
+ *
+ * For example, "efnahagsráðherra" might be split as:
+ *   - ["efnahags", "ráðherra"]
+ *   - ["efna", "hags", "ráðherra"]
+ *
+ * The navigator returns all possible splits where each part is a valid
+ * word in the DAWG.
+ *
+ * This is used by DAWG_Dictionary::find_combinations() for compound
+ * word analysis in Icelandic text processing.
+ */
+class CompoundNavigator : public Navigator {
+private:
+    DAWG_Dictionary* m_dawg;
+    const std::string& m_word;
+    size_t m_len;
+    size_t m_index;
+    std::vector<std::vector<std::string>> m_parts;
+
+public:
+    CompoundNavigator(DAWG_Dictionary* dawg, const std::string& word);
+
+    bool push_edge(char firstchar) override {
+        if (m_index >= m_len) return false;
+        return m_word[m_index] == firstchar;
+    }
+
+    bool accepting() override {
+        return m_index < m_len;
+    }
+
+    bool accepts(char newchar) override {
+        if (m_index >= m_len || newchar != m_word[m_index]) {
+            return false;
+        }
+        m_index++;
+        return true;
+    }
+
+    void accept(const std::string& matched, bool final) override;
+
+    bool pop_edge() override {
+        return false; // Short-circuit
+    }
+
+    std::vector<std::vector<std::string>> result() const {
+        return m_parts;
+    }
+};
+
+/**
+ * Main DAWG dictionary class.
+ *
+ * DAWG_Dictionary loads and provides access to a packed binary DAWG file.
+ * It handles:
+ *   - Loading and parsing the binary file format
+ *   - Building the character encoding map from the vocabulary
+ *   - Providing word lookup (contains) and compound splitting (find_combinations)
+ *   - Caching parsed nodes for performance
+ *
+ * The dictionary is initialized from a memory-mapped file pointer and
+ * maintains references to that memory throughout its lifetime. The caller
+ * is responsible for keeping the memory mapping valid.
+ */
+class DAWG_Dictionary {
+private:
+    // Pointer to memory-mapped DAWG file data
+    const BYTE* m_pbMap;
+
+    // Byte offset in m_pbMap where the root node begins
+    UINT32 m_root_offset;
+
+    // Encoding map: byte code -> character string
+    // Maps vocabulary indices (0, 1, 2, ...) to their characters.
+    // Also maps (index | 0x80) to character with '|' suffix for finality.
+    std::map<int, std::string> m_encoding;
+
+    // Cache of parsed nodes: node_offset -> (prefix -> next_node_offset)
+    // Avoids re-parsing the same node multiple times during navigation.
+    std::map<UINT32, std::map<std::string, UINT32>> m_iter_cache;
+
+public:
+    /**
+     * Load a DAWG dictionary from a memory-mapped file.
+     * @param pbMap Pointer to the beginning of the DAWG file in memory
+     * @throws std::runtime_error if the file signature is invalid
+     */
+    DAWG_Dictionary(const BYTE* pbMap);
+    ~DAWG_Dictionary();
+
+    /**
+     * Check if a word exists in the dictionary.
+     * @param word Latin-1 encoded word to search for
+     * @return true if word is in the dictionary, false otherwise
+     */
+    bool contains(const std::string& word);
+
+    /**
+     * Find all ways to split a word into valid dictionary parts.
+     * @param word Latin-1 encoded word to split
+     * @return Vector of possible splits, each split is a vector of word parts
+     *         Returns empty vector if no valid splits exist
+     */
+    std::vector<std::vector<std::string>> find_combinations(const std::string& word);
+
+    /**
+     * Navigate the DAWG using a custom Navigator strategy.
+     * @param nav Navigator that controls the traversal logic
+     */
+    void navigate(Navigator& nav);
+
+    friend class PackedNavigation;
+};
+
+/**
+ * Navigation engine for traversing the packed DAWG.
+ *
+ * PackedNavigation handles the low-level details of:
+ *   - Parsing node and edge structures from the binary format
+ *   - Decoding character codes using the encoding map
+ *   - Managing the navigation state (current position, matched prefix)
+ *   - Delegating control decisions to the Navigator
+ *
+ * It works by starting at the root node and recursively following edges
+ * that the Navigator approves, calling Navigator::accept() when matches
+ * (partial or complete words) are found.
+ */
+class PackedNavigation {
+private:
+    Navigator& m_nav;
+    DAWG_Dictionary* m_dawg;
+    const BYTE* m_b;
+    UINT32 m_root_offset;
+
+    void navigate_from_node(UINT32 offset, std::string matched);
+    void navigate_from_edge(const std::string& prefix, UINT32 nextnode, std::string matched);
+
+public:
+    PackedNavigation(Navigator& nav, DAWG_Dictionary* dawg)
+        : m_nav(nav), m_dawg(dawg), m_b(dawg->m_pbMap), m_root_offset(dawg->m_root_offset) {}
+
+    void go();
+};
+
+CompoundNavigator::CompoundNavigator(DAWG_Dictionary* dawg, const std::string& word)
+    : m_dawg(dawg), m_word(word), m_len(word.length()), m_index(0) {}
+
+/**
+ * Accept a matched word and recursively search for splits of the remainder.
+ *
+ * This is where the compound word splitting magic happens:
+ *
+ * 1. If we've matched a complete word (final=true):
+ *    a. If we've consumed the entire input word: record single-part solution
+ *    b. If there's remaining text: recursively search for ways to split it
+ *       - Create a new CompoundNavigator for the remainder
+ *       - For each valid split of the remainder, prepend our matched part
+ *       - Record all resulting combinations
+ *
+ * For example, with "efnahagsráðherra":
+ *   - When "efnahags" matches (final=true), remainder is "ráðherra"
+ *   - Recursive search finds ["ráðherra"] and ["ráð", "herra"]
+ *   - Results: ["efnahags", "ráðherra"], ["efnahags", "ráð", "herra"]
+ *
+ * @param matched The word part matched so far
+ * @param final   True if matched is a complete word in the dictionary
+ */
+void CompoundNavigator::accept(const std::string& matched, bool final) {
+    if (final) {
+        if (m_index == m_len) {
+            // We've consumed the entire input word - single part solution
+            m_parts.push_back({matched});
+        } else {
+            // There's more to match - recursively split the remainder
+            std::string remainder = m_word.substr(m_index);
+            CompoundNavigator nav(m_dawg, remainder);
+            m_dawg->navigate(nav);
+            std::vector<std::vector<std::string>> result = nav.result();
+            if (!result.empty()) {
+                // For each way to split the remainder, prepend our matched part
+                for (const auto& tail : result) {
+                    std::vector<std::string> combination = {matched};
+                    combination.insert(combination.end(), tail.begin(), tail.end());
+                    m_parts.push_back(combination);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Load and initialize a DAWG dictionary from a memory-mapped file.
+ *
+ * This constructor:
+ * 1. Validates the file signature
+ * 2. Reads the vocabulary section (UTF-8 encoded)
+ * 3. Converts vocabulary to Latin-1 for easier processing
+ * 4. Builds the encoding map for decoding edge prefixes
+ * 5. Calculates the root node offset
+ *
+ * ENCODING MAP CONSTRUCTION:
+ *
+ * The encoding map is critical for decoding the packed format. Each
+ * character in the vocabulary gets an index (0, 1, 2, ...). The DAWG
+ * stores character INDICES (not the characters themselves) in edges.
+ *
+ * We create two map entries per character:
+ *   - index i: Maps to the character (e.g., 'a')
+ *   - index i|0x80: Maps to character+'|' (e.g., 'a|')
+ *
+ * The '|' suffix indicates a word boundary (finality marker). During
+ * edge traversal, when we decode a byte with the 0x80 bit set, we get
+ * the character plus '|', signaling that the word up to that point is
+ * a complete dictionary entry.
+ *
+ * @param pbMap Pointer to the beginning of the DAWG file in memory
+ * @throws std::runtime_error if file signature is invalid
+ */
+DAWG_Dictionary::DAWG_Dictionary(const BYTE* pbMap) : m_pbMap(pbMap) {
+    // Verify file signature
+    if (memcmp(m_pbMap, "ReynirDawg!\n", 12) != 0) {
+        throw std::runtime_error("Invalid DAWG file signature");
+    }
+
+    // Read vocabulary length (bytes 12-15, little-endian uint32)
+    UINT32 len_voc = *(UINT32*)(m_pbMap + 12);
+
+    // Vocabulary starts at byte 16
+    const char* voc_bytes = (const char*)(m_pbMap + 16);
+
+    // Graph data starts immediately after vocabulary
+    m_root_offset = 16 + len_voc;
+
+    // Convert UTF-8 vocabulary to Latin-1
+    // We use Latin-1 because all Icelandic characters fit in ISO-8859-1,
+    // and it simplifies string handling (one byte per character)
+    std::string voc_string_latin1 = utf8_to_latin1(voc_bytes, len_voc);
+
+    // Build encoding map: vocabulary index -> character (with/without finality marker)
+    // IMPORTANT: We map CHARACTER INDICES, not byte positions in the UTF-8 string!
+    // This matches Python's: {i: char for i, char in enumerate(vocabulary)}
+    for (size_t i = 0; i < voc_string_latin1.length(); ++i) {
+        std::string c = voc_string_latin1.substr(i, 1);
+        m_encoding[i] = c;              // Normal character
+        m_encoding[i | 0x80] = c + "|"; // Character with finality marker
+    }
+}
+
+DAWG_Dictionary::~DAWG_Dictionary() {}
+
+bool DAWG_Dictionary::contains(const std::string& word) {
+    FindNavigator nav(word);
+    navigate(nav);
+    return nav.is_found();
+}
+
+std::vector<std::vector<std::string>> DAWG_Dictionary::find_combinations(const std::string& word) {
+    CompoundNavigator nav(this, word);
+    navigate(nav);
+    return nav.result();
+}
+
+void DAWG_Dictionary::navigate(Navigator& nav) {
+    PackedNavigation(nav, this).go();
+}
+
+/**
+ * Start navigation from the root node.
+ */
+void PackedNavigation::go() {
+    if (m_nav.accepting()) {
+        navigate_from_node(m_root_offset, "");
+    }
+}
+
+/**
+ * Navigate from a node by exploring its outgoing edges.
+ *
+ * This method handles the core node parsing logic:
+ *
+ * 1. Check cache: If we've parsed this node before, use cached edges
+ * 2. Parse node structure from binary:
+ *    a. Read number of edges from node header
+ *    b. For each edge:
+ *       - Read edge length byte
+ *       - Decode character codes into prefix string using encoding map
+ *       - Check finality of LAST character (critical!)
+ *       - Read next node offset (if not final)
+ *    c. Cache the parsed edges
+ * 3. Traverse edges: For each edge, ask Navigator if we should explore it
+ *
+ * CRITICAL: Finality check must only examine the LAST byte of the prefix!
+ * Checking other bytes causes incorrect offset calculations and crashes.
+ * This is because intermediate characters may have the 0x80 bit set as
+ * part of their vocabulary index, not as a finality marker.
+ *
+ * @param offset  Byte offset in m_b where this node begins
+ * @param matched String matched so far (path from root to this node)
+ */
+void PackedNavigation::navigate_from_node(UINT32 offset, std::string matched) {
+    // Check if we've already parsed this node (performance optimization)
+    auto it = m_dawg->m_iter_cache.find(offset);
+
+    if (it == m_dawg->m_iter_cache.end()) {
+        // First time visiting this node - parse its structure
+        std::map<std::string, UINT32> edges;
+        const BYTE* b = m_b;
+        UINT32 current_offset = offset;
+
+        // Node header: lower 7 bits = number of outgoing edges
+        BYTE num_edges = b[current_offset++] & 0x7F;
+
+        // Parse each edge
+        for (int i = 0; i < num_edges; ++i) {
+            // Edge header: lower 7 bits = number of character codes in prefix
+            BYTE len_byte = b[current_offset++] & 0x7F;
+
+            // Decode the character codes into a prefix string
+            std::string prefix = "";
+            for (int j = 0; j < len_byte; ++j) {
+                BYTE code = b[current_offset + j];
+                auto it = m_dawg->m_encoding.find(code);
+                if (it == m_dawg->m_encoding.end()) {
+                    throw std::runtime_error("Invalid encoding in DAWG file");
+                }
+                prefix += it->second;
+            }
+            current_offset += len_byte;
+
+            // Check finality: Does the LAST byte have the 0x80 bit set?
+            // IMPORTANT: Only check the LAST byte! Checking other bytes breaks offset calculation.
+            bool is_final = (b[current_offset - 1] & 0x80) != 0;
+
+            // Read next node offset (only present if edge is not final)
+            UINT32 nextnode = 0;
+            if (!is_final) {
+                nextnode = *(UINT32*)(b + current_offset);
+                current_offset += 4;
+            }
+
+            edges[prefix] = nextnode;
+        }
+
+        // Cache the parsed edges for future visits to this node
+        m_dawg->m_iter_cache[offset] = edges;
+        it = m_dawg->m_iter_cache.find(offset);
+    }
+
+    // Traverse the edges, asking Navigator which ones to explore
+    for (const auto& edge : it->second) {
+        const std::string& prefix = edge.first;
+        UINT32 nextnode = edge.second;
+
+        // Ask Navigator: should we explore this edge?
+        if (!prefix.empty() && m_nav.push_edge(prefix[0])) {
+            navigate_from_edge(prefix, nextnode, matched);
+
+            // Ask Navigator: should we continue to other edges?
+            if (!m_nav.pop_edge()) {
+                break;  // Short-circuit: stop exploring other edges from this node
+            }
+        }
+    }
+}
+
+/**
+ * Navigate along an edge, processing its prefix character by character.
+ *
+ * This method walks along a single edge from a node, character by character,
+ * checking with the Navigator at each step and detecting word boundaries.
+ *
+ * The prefix may contain finality markers ('|') indicating points where
+ * valid words end. For example, prefix "ing|s|" encodes two words:
+ *   - "...ing" (word ends at first |)
+ *   - "...ings" (word ends at second |)
+ *
+ * Algorithm:
+ * 1. For each character in the prefix:
+ *    a. If it's '|': signal a final word to Navigator, continue
+ *    b. Otherwise: ask Navigator if it accepts this character
+ *       - If rejected: stop traversing this edge
+ *       - If accepted: add to matched string and continue
+ *    c. Check if current position is a word boundary:
+ *       - Look ahead: is next char '|'?
+ *       - Look at node: if we're at end and nextnode is final or absent
+ *    d. Signal match (final or non-final) to Navigator
+ *
+ * 2. After consuming the prefix:
+ *    - If there's a next node and Navigator is still accepting: recurse
+ *
+ * @param prefix   Decoded edge prefix (may contain '|' finality markers)
+ * @param nextnode Offset of the next node (0 if edge is terminal)
+ * @param matched  String matched so far (path from root to edge start)
+ */
+void PackedNavigation::navigate_from_edge(const std::string& prefix, UINT32 nextnode, std::string matched) {
+    size_t lenp = prefix.length();
+    size_t j = 0;
+
+    // Walk through the prefix character by character
+    while (j < lenp && m_nav.accepting()) {
+        char current_char = prefix[j];
+
+        // Finality marker: signals a complete word at this position
+        if (current_char == '|') {
+             m_nav.accept(matched, true);  // Final=true: complete word
+             j++;
+             continue;
+        }
+
+        // Ask Navigator: do you accept this character?
+        if (!m_nav.accepts(current_char)) {
+            return;  // Navigator rejected this character, stop navigating this edge
+        }
+
+        // Accepted! Add character to our matched string
+        matched += current_char;
+        j++;
+
+        // Determine if this position marks the end of a word
+        bool final = false;
+        if (j < lenp) {
+            // Not at end of prefix - check if next char is finality marker
+            if (prefix[j] == '|') {
+                final = true;
+            }
+        } else {
+            // At end of prefix - check if the edge/node is final
+            // Final if: nextnode is 0 (terminal) or next node header has 0x80 bit
+            if (nextnode == 0 || (m_b[nextnode] & 0x80)) {
+                final = true;
+            }
+        }
+
+        // Notify Navigator of the match (final or partial)
+        m_nav.accept(matched, final);
+    }
+
+    // Handle any trailing finality marker
+    if (j < lenp && prefix[j] == '|') {
+         m_nav.accept(matched, true);
+    } else if (j < lenp) {
+        // Didn't consume entire prefix - Navigator stopped accepting
+        return;
+    }
+
+    // Continue to next node if it exists and Navigator wants to continue
+    if (nextnode != 0 && m_nav.accepting()) {
+        navigate_from_node(nextnode, matched);
+    }
+}
+
+// ============================================================================
+// C-style API implementation
+//
+// These functions provide a C interface to the C++ DAWG implementation,
+// allowing Python (via CFFI) and other C clients to use the dictionary.
+// ============================================================================
+
+/**
+ * Load a DAWG dictionary from a memory-mapped file.
+ *
+ * @param pbMap Pointer to the beginning of the DAWG file in memory
+ * @return Opaque handle to the DAWG dictionary, or NULL if loading fails
+ *
+ * @note The caller must ensure the memory mapping remains valid for the
+ *       lifetime of the returned handle.
+ */
+DawgHandle dawg_load(const BYTE* pbMap) {
+    try {
+        return new DAWG_Dictionary(pbMap);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+/**
+ * Unload a DAWG dictionary and free its resources.
+ *
+ * @param handle Handle returned by dawg_load()
+ *
+ * @note Does NOT unmap the file - the caller is responsible for that.
+ */
+void dawg_unload(DawgHandle handle) {
+    if (handle) {
+        delete static_cast<DAWG_Dictionary*>(handle);
+    }
+}
+
+/**
+ * Check if a word exists in the DAWG dictionary.
+ *
+ * @param handle Handle returned by dawg_load()
+ * @param word   Latin-1 encoded word to search for
+ * @return true if word exists in dictionary, false otherwise
+ */
+bool dawg_contains(DawgHandle handle, const char* word) {
+    if (!handle || !word) return false;
+    std::string s_latin1(word);
+    return static_cast<DAWG_Dictionary*>(handle)->contains(s_latin1);
+}
+
+/**
+ * Serialize compound word combinations to JSON format.
+ *
+ * Converts a vector of word-part vectors into a JSON string:
+ *   [["part1", "part2"], ["part1", "part2", "part3"]]
+ *
+ * This format is easy to parse in Python using json.loads().
+ *
+ * @param combinations Vector of word splits to serialize
+ * @return Newly allocated JSON string (caller must free with dawg_free_string)
+ */
+char* serialize_combinations(const std::vector<std::vector<std::string>>& combinations) {
+    std::stringstream ss;
+    ss << "[";
+    for (size_t i = 0; i < combinations.size(); ++i) {
+        if (i > 0) ss << ",";
+        ss << "[";
+        for (size_t j = 0; j < combinations[i].size(); ++j) {
+            if (j > 0) ss << ",";
+            ss << "\"";
+            // Escape quotes and backslashes in JSON string
+            for (char c : combinations[i][j]) {
+                 if (c == '"' || c == '\\') {
+                    ss << '\\';
+                }
+                ss << c;
+            }
+            ss << "\"";
+        }
+        ss << "]";
+    }
+    ss << "]";
+
+    std::string s = ss.str();
+    char* result = new char[s.length() + 1];
+    std::strcpy(result, s.c_str());
+    return result;
+}
+
+/**
+ * Find all possible ways to split a word into valid dictionary parts.
+ *
+ * Used for compound word analysis: given an unknown word, attempts to
+ * split it into known parts. For example, "efnahagsráðherra" might
+ * split into ["efnahags", "ráðherra"].
+ *
+ * @param handle Handle returned by dawg_load()
+ * @param word   Latin-1 encoded word to split
+ * @return JSON string of combinations, or NULL if no splits found
+ *         Caller must free the returned string with dawg_free_string()
+ */
+char* dawg_find_combinations(DawgHandle handle, const char* word) {
+    if (!handle || !word) return nullptr;
+    std::string s_latin1(word);
+    auto combinations = static_cast<DAWG_Dictionary*>(handle)->find_combinations(s_latin1);
+    if (combinations.empty()) {
+        return nullptr;
+    }
+    return serialize_combinations(combinations);
+}
+
+/**
+ * Free a string returned by dawg_find_combinations().
+ *
+ * @param str String to free (may be NULL)
+ */
+void dawg_free_string(char* str) {
+    if (str) {
+        delete[] str;
+    }
+}

--- a/src/islenska/dawgdictionary.cpp
+++ b/src/islenska/dawgdictionary.cpp
@@ -789,12 +789,37 @@ bool dawg_contains(DawgHandle handle, const char* word) {
 }
 
 /**
- * Serialize compound word combinations to JSON format.
+ * Append a Latin-1 string to a stream as UTF-8 with JSON escaping.
+ *
+ * Handles both UTF-8 conversion and JSON special character escaping.
+ *
+ * @param os Output stream to append to
+ * @param latin1 Latin-1 encoded string to convert and append
+ */
+static void append_latin1_as_utf8_json(std::ostream& os, const std::string& latin1) {
+    for (unsigned char c : latin1) {
+        // JSON escaping for special characters
+        if (c == '"' || c == '\\') {
+            os << '\\' << c;
+        } else if (c < 0x80) {
+            // ASCII range: single byte
+            os << c;
+        } else {
+            // Latin-1 extended range: two bytes in UTF-8
+            os << static_cast<char>(0xC0 | (c >> 6));
+            os << static_cast<char>(0x80 | (c & 0x3F));
+        }
+    }
+}
+
+/**
+ * Serialize compound word combinations to JSON format with UTF-8 encoding.
  *
  * Converts a vector of word-part vectors into a JSON string:
  *   [["part1", "part2"], ["part1", "part2", "part3"]]
  *
- * This format is easy to parse in Python using json.loads().
+ * Converts all Latin-1 strings to UTF-8 for JSON output, allowing
+ * Python's json.loads() to consume the bytes directly without decoding.
  *
  * @param combinations Vector of word splits to serialize
  * @return Newly allocated JSON string (caller must free with dawg_free_string)
@@ -808,13 +833,7 @@ char* serialize_combinations(const std::vector<std::vector<std::string>>& combin
         for (size_t j = 0; j < combinations[i].size(); ++j) {
             if (j > 0) ss << ",";
             ss << "\"";
-            // Escape quotes and backslashes in JSON string
-            for (char c : combinations[i][j]) {
-                 if (c == '"' || c == '\\') {
-                    ss << '\\';
-                }
-                ss << c;
-            }
+            append_latin1_as_utf8_json(ss, combinations[i][j]);
             ss << "\"";
         }
         ss << "]";

--- a/src/islenska/dawgdictionary.h
+++ b/src/islenska/dawgdictionary.h
@@ -1,0 +1,67 @@
+/*
+
+   BinPackage
+
+   C++ DAWG dictionary module
+
+   Copyright © 2025 Miðeind ehf.
+   Original author: Vilhjálmur Þorsteinsson
+
+   This software is licensed under the MIT License:
+
+      Permission is hereby granted, free of charge, to any person
+      obtaining a copy of this software and associated documentation
+      files (the "Software"), to deal in the Software without restriction,
+      including without limitation the rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the Software,
+      and to permit persons to whom the Software is furnished to do so,
+      subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be
+      included in all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <stdint.h>
+
+// C99 bool support (C++ has bool built-in)
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+typedef uint8_t BYTE;
+
+// Opaque handle for the DAWG dictionary
+typedef void* DawgHandle;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Load a DAWG from a memory map. Returns a handle.
+DawgHandle dawg_load(const BYTE* pbMap);
+
+// Unload a DAWG and free resources.
+void dawg_unload(DawgHandle handle);
+
+// Check if a word exists in the DAWG. Returns true if found, false otherwise.
+bool dawg_contains(DawgHandle handle, const char* word);
+
+// Find compound word combinations.
+// Returns a result string that needs to be freed with dawg_free_string().
+char* dawg_find_combinations(DawgHandle handle, const char* word);
+
+// Free the string returned by dawg_find_combinations.
+void dawg_free_string(char* str);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/islenska/dawgdictionary.py
+++ b/src/islenska/dawgdictionary.py
@@ -103,8 +103,9 @@ class Dawg:
             return []
 
         try:
-            result_str = ffi.string(result_ptr).decode("latin-1")
-            return json.loads(result_str)
+            # C++ now returns UTF-8 bytes
+            result_bytes = ffi.string(result_ptr)
+            return json.loads(result_bytes)  # json.loads accepts UTF-8 bytes
         finally:
             dawg_cffi.dawg_free_string(result_ptr)
 

--- a/src/islenska/dawgdictionary.py
+++ b/src/islenska/dawgdictionary.py
@@ -39,49 +39,101 @@
 
 """
 
-from typing import Dict, List, Optional, Union, Tuple, Iterator, ItemsView, cast
-
+from typing import List, Optional, IO, Any, cast
 import os
 import threading
-import struct
 import mmap
+import json
 
 import importlib.resources as importlib_resources
+
+# CFFI bindings to the C++ implementation
+from ._bin import lib as lib_unknown, ffi as ffi_unknown  # type: ignore
+
+
+# Go through shenanigans to satisfy Pylance/Mypy
+dawg_cffi = cast(Any, lib_unknown)
+ffi = cast(Any, ffi_unknown)
+
 
 _PATH = os.path.dirname(__file__) or "."
 
 
-class Wordbase:
-    """Container for a singleton instance of the word database"""
+class Dawg:
+    """A wrapper for the C++ DAWG implementation."""
 
-    # All word forms
-    _dawg_all: Optional["PackedDawgDictionary"] = None
-    # Word forms allowed as former parts of compounds
-    _dawg_prefixes: Optional["PackedDawgDictionary"] = None
-    # Word forms allowed as last part of compounds
-    _dawg_suffixes: Optional["PackedDawgDictionary"] = None
+    def __init__(self, fname: str) -> None:
+        self._handle: Optional[object] = None
+        self._mmap: Optional[mmap.mmap] = None
+        self._stream: Optional[IO[bytes]] = None
+
+        self._stream = open(fname, "rb")
+        self._mmap = mmap.mmap(self._stream.fileno(), 0, access=mmap.ACCESS_READ)
+
+        # Pass the memory map pointer to the C++ loader
+        self._handle = dawg_cffi.dawg_load(ffi.from_buffer(self._mmap))
+        if not self._handle:
+            raise MemoryError(f"Unable to load DAWG file: {fname}")
+
+    def __del__(self) -> None:
+        if self._handle:
+            dawg_cffi.dawg_unload(self._handle)
+            self._handle = None
+        if self._mmap:
+            self._mmap.close()
+            self._mmap = None
+        if self._stream:
+            self._stream.close()
+            self._stream = None
+
+    def __contains__(self, word: str) -> bool:
+        if not self._handle:
+            return False
+        word_bytes = word.encode("latin-1")
+        return dawg_cffi.dawg_contains(self._handle, word_bytes)
+
+    def find_combinations(self, word: str) -> List[List[str]]:
+        """Attempt to slice a word into valid parts using the DAWG."""
+        if not self._handle:
+            return []
+
+        word_bytes = word.encode("latin-1")
+        result_ptr = dawg_cffi.dawg_find_combinations(self._handle, word_bytes)
+        if not result_ptr:
+            return []
+
+        try:
+            result_str = ffi.string(result_ptr).decode("latin-1")
+            return json.loads(result_str)
+        finally:
+            dawg_cffi.dawg_free_string(result_ptr)
+
+
+class Wordbase:
+    """Container for singleton instances of the DAWG dictionaries."""
+
+    _dawg_all: Optional[Dawg] = None
+    _dawg_prefixes: Optional[Dawg] = None
+    _dawg_suffixes: Optional[Dawg] = None
 
     _lock = threading.Lock()
 
     @staticmethod
-    def _load_resource(resource: str) -> "PackedDawgDictionary":
-        """Load a PackedDawgDictionary from a file"""
-        # Assumes that the appropriate lock has been acquired
+    def _load_resource(resource: str) -> Dawg:
+        """Load a Dawg from a file resource."""
         if __package__:
-            # If we're inside a package (which is by far the most common case),
-            # obtain the name of a resource file through importlib.
             ref = importlib_resources.files("islenska") / "resources" / f"{resource}.dawg.bin"
             with importlib_resources.as_file(ref) as path:
                 pname = str(path)
         else:
-            pname = os.path.abspath(os.path.join(_PATH, "resources", resource + ".dawg.bin"))
-        dawg = PackedDawgDictionary()
-        dawg.load(pname)
-        return dawg
+            pname = os.path.abspath(
+                os.path.join(_PATH, "resources", resource + ".dawg.bin")
+            )
+        return Dawg(pname)
 
     @classmethod
-    def dawg(cls) -> "PackedDawgDictionary":
-        """Load the combined dictionary"""
+    def dawg(cls) -> Dawg:
+        """Load the combined dictionary."""
         with cls._lock:
             if cls._dawg_all is None:
                 cls._dawg_all = Wordbase._load_resource("ordalisti-all")
@@ -89,10 +141,8 @@ class Wordbase:
             return cls._dawg_all
 
     @classmethod
-    def dawg_prefixes(cls) -> "PackedDawgDictionary":
-        """Load the dictionary of words allowed as prefixes
-        in a compound word (i.e. can occur in any part except
-        the last part of the compound word)"""
+    def dawg_prefixes(cls) -> Dawg:
+        """Load the dictionary of words allowed as prefixes."""
         with cls._lock:
             if cls._dawg_prefixes is None:
                 cls._dawg_prefixes = Wordbase._load_resource("ordalisti-prefixes")
@@ -100,9 +150,8 @@ class Wordbase:
             return cls._dawg_prefixes
 
     @classmethod
-    def dawg_suffixes(cls) -> "PackedDawgDictionary":
-        """Load the dictionary of words that are allowed as the last
-        part of a compound word"""
+    def dawg_suffixes(cls) -> Dawg:
+        """Load the dictionary of words allowed as suffixes."""
         with cls._lock:
             if cls._dawg_suffixes is None:
                 cls._dawg_suffixes = Wordbase._load_resource("ordalisti-suffixes")
@@ -111,7 +160,7 @@ class Wordbase:
 
     @classmethod
     def slice_compound_word(cls, word: str) -> List[str]:
-        """Get best combination of word parts if such a combination exists"""
+        """Get best combination of word parts if such a combination exists."""
         # We get back a list of lists, i.e. all possible compound word combinations
         # where each combination is a list of word parts.
         w = cls.dawg().find_combinations(word)
@@ -124,305 +173,11 @@ class Wordbase:
             # i.e. where the suffix is a legal suffix and all prefixes are
             # legal prefixes
             for combination in w:
-                if combination[-1] in suffixes and all(c in prefixes for c in combination[0:-1]):
+                if (
+                    combination[-1] in suffixes
+                    and all(c in prefixes for c in combination[0:-1])
+                ):
                     # Valid combination: return it
                     return combination
         # No legal combination found
         return []
-
-
-class FindNavigator:
-    """A navigation class to be used with DawgDictionary.navigate()
-    to find a particular word in the dictionary by exact match
-    """
-
-    def __init__(self, word: str) -> None:
-        self._word = word
-        self._len = len(word)
-        self._index = 0
-        self._found = False
-
-    def push_edge(self, firstchar: str) -> bool:
-        """Returns True if the edge should be entered or False if not"""
-        # Enter the edge if it fits where we are in the word
-        return self._word[self._index] == firstchar
-
-    def accepting(self) -> bool:
-        """Returns False if the navigator does not want more characters"""
-        # Don't go too deep
-        return self._index < self._len
-
-    def accepts(self, newchar: str) -> bool:
-        """Returns True if the navigator will accept the new character"""
-        if newchar != self._word[self._index]:
-            return False
-        # Match: move to the next index position
-        self._index += 1
-        return True
-
-    def accept(self, matched: str, final: bool) -> None:
-        """Called to inform the navigator of a match and whether it is a final word"""
-        if final and self._index == self._len:
-            # Yes, this is what we were looking for
-            assert matched == self._word
-            self._found = True
-
-    # noinspection PyMethodMayBeStatic
-    def pop_edge(self) -> bool:
-        """Called when leaving an edge that has been navigated"""
-        # We only need to visit one outgoing edge, so short-circuit the edge loop
-        return False
-
-    def is_found(self) -> bool:
-        return self._found
-
-
-class CompoundNavigator:
-    """A navigation class to be used with DawgDictionary.navigate()
-    to find all possible compositions of shorter words that
-    together form a long (compound) word.
-    """
-
-    def __init__(self, dawg: "PackedDawgDictionary", word: str) -> None:
-        self._dawg = dawg
-        self._word = word
-        self._len = len(word)
-        self._index = 0
-        self._parts: List[List[str]] = []
-
-    def push_edge(self, firstchar: str) -> bool:
-        """Returns True if the edge should be entered or False if not"""
-        # Follow all edges that match a letter in the compound word
-        return self._word[self._index] == firstchar
-
-    def accepting(self) -> bool:
-        """Returns False if the navigator does not want more characters"""
-        # Continue until we have generated all left parts possible from the
-        # rack but leaving at least one tile
-        return self._index < self._len
-
-    def accepts(self, newchar: str) -> bool:
-        """Returns True if the navigator will accept the new character"""
-        if newchar != self._word[self._index]:
-            return False
-        self._index += 1
-        return True
-
-    def accept(self, matched: str, final: bool) -> None:
-        """Called to inform the navigator of a match and whether it is a final word"""
-        if final:
-            # We have a valid word so far: attempt to resolve the following text
-            if self._index == self._len:
-                # Complete match: return a single part
-                self._parts = [[matched]]
-            else:
-                # So far so good: try to match the rest
-                nav = CompoundNavigator(self._dawg, self._word[self._index :])
-                self._dawg.navigate(nav)
-                result = nav.result()
-                if result:
-                    self._parts.extend([[matched] + tail for tail in result])
-
-    # noinspection PyMethodMayBeStatic
-    def pop_edge(self) -> bool:
-        """Called when leaving an edge that has been navigated"""
-        return False
-
-    def result(self) -> List[List[str]]:
-        return self._parts
-
-
-class PackedDawgDictionary:
-    """Encapsulates a DAWG dictionary that is initialized from a packed
-    binary file on disk and navigated as a byte buffer."""
-
-    def __init__(self) -> None:
-        # The packed byte buffer
-        self._b: Optional[mmap.mmap] = None
-        self._vocabulary: Optional[str] = None
-        self._root_offset = 0
-        self._encoding: Dict[int, str] = dict()
-
-    def load(self, fname: str) -> None:
-        """Load a packed DAWG from a binary file"""
-        if self._b is not None:
-            # Already loaded
-            return
-        # Map the file contents to a memory map, reflected in a byte buffer
-        with open(fname, mode="rb") as stream:
-            self._b = mmap.mmap(stream.fileno(), 0, access=mmap.ACCESS_READ)
-        # Check the signature
-        assert self._b[0:12] == b"ReynirDawg!\n"
-        # Get the DAWG vocabulary (alphabet)
-        (len_voc,) = struct.Struct("<L").unpack_from(self._b, 12)
-        self._vocabulary = self._b[16 : 16 + len_voc].decode("utf-8")
-        self._root_offset = 16 + len_voc
-        # Assemble a decoding dictionary where encoded indices are mapped to
-        # characters, eventually with a suffixed vertical bar '|' to denote finality
-        self._encoding = {i: c for i, c in enumerate(self._vocabulary)}
-        self._encoding.update({i | 0x80: c + "|" for i, c in enumerate(self._vocabulary)})
-
-    def find(self, word: str) -> bool:
-        """Look for a word in the graph, returning True
-        if it is found or False if not"""
-        return self.__contains__(word)
-
-    def __contains__(self, word: str) -> bool:
-        """Enable simple lookup syntax: "word" in dawgdict"""
-        nav = FindNavigator(word)
-        self.navigate(nav)
-        return nav.is_found()
-
-    def find_combinations(self, word: str):
-        """Attempt to slice an unknown word into parts, where each part is
-        a valid word form in itself, and the parts form a valid compound word."""
-        nav = CompoundNavigator(self, word)
-        self.navigate(nav)
-        return nav.result()
-
-    def navigate(self, nav: Union[FindNavigator, CompoundNavigator]) -> None:
-        """A generic function to navigate through the DAWG under
-        the control of a navigation object.
-
-        The navigation object should implement the following interface:
-
-        def push_edge(firstchar)
-            returns True if the edge should be entered or False if not
-        def accepting()
-            returns False if the navigator does not want more characters
-        def accepts(newchar)
-            returns True if the navigator will accept and 'eat' the new character
-        def accept(matched, final)
-            called to inform the navigator of a match and whether
-            it is a final word
-        def pop_edge()
-            called when leaving an edge that has been navigated; returns False
-            if there is no need to visit other edges
-        """
-        assert self._b is not None
-        PackedNavigation(nav, self._b, self._root_offset, self._encoding).go()
-
-
-class PackedNavigation:
-    """Manages the state for a navigation while it is in progress"""
-
-    # The structure used to decode an edge offset from bytes
-    _UINT32 = struct.Struct("<L")
-
-    # Dictionary of edge iteration caches, keyed by byte buffer
-    _iter_caches: Dict[int, Dict[int, Dict[str, int]]] = dict()
-
-    def __init__(
-        self,
-        nav: Union[FindNavigator, CompoundNavigator],
-        b: mmap.mmap,
-        root_offset: int,
-        encoding: Dict[int, str],
-    ) -> None:
-        # Store the associated navigator
-        self._nav = nav
-        # The DAWG bytearray
-        self._b = b
-        self._root_offset = root_offset
-        self._encoding = encoding
-        self._iter_cache: Dict[int, Dict[str, int]]
-        if id(b) in self._iter_caches:
-            # We already have a cache associated with this byte buffer
-            self._iter_cache = self._iter_caches[id(b)]
-        else:
-            # Create a fresh cache for this byte buffer
-            self._iter_cache = self._iter_caches[id(b)] = cast(Dict[int, Dict[str, int]], dict())
-
-    def _iter_from_node(self, offset: int) -> Iterator[Tuple[str, int]]:
-        """A generator for yielding prefixes and next node offset along an edge
-        starting at the given offset in the DAWG bytearray"""
-        b = self._b
-        encoding = self._encoding
-        num_edges = b[offset] & 0x7F
-        offset += 1
-        for _ in range(num_edges):
-            len_byte = b[offset] & 0x7F
-            offset += 1
-            prefix = "".join(encoding[b[offset + j]] for j in range(len_byte))
-            offset += len_byte
-            if b[offset - 1] & 0x80:
-                # The last character of the prefix had a final marker: nextnode is 0
-                nextnode = 0
-            else:
-                # Read the next node offset
-                (nextnode,) = self._UINT32.unpack_from(b, offset)  # Tuple of length 1, i.e. (n, )
-                offset += 4
-            yield prefix, nextnode
-
-    def _make_iter_from_node(self, offset: int) -> ItemsView[str, int]:
-        """Return an iterator over the prefixes and next node pointers
-        of the edge at the given offset. If this is the first time
-        that the edge is iterated, cache its unpacked contents
-        in a dictionary for quicker subsequent iteration."""
-        d: Dict[str, int]
-        try:
-            d = self._iter_cache[offset]
-        except KeyError:
-            d = {prefix: nextnode for prefix, nextnode in self._iter_from_node(offset)}
-            self._iter_cache[offset] = d
-        return d.items()
-
-    def _navigate_from_node(self, offset: int, matched: str) -> None:
-        """Starting from a given node, navigate outgoing edges"""
-        # Go through the edges of this node and follow the ones
-        # okayed by the navigator
-        nav = self._nav
-        for prefix, nextnode in self._make_iter_from_node(offset):
-            if nav.push_edge(prefix[0]):
-                # This edge is a candidate: navigate through it
-                self._navigate_from_edge(prefix, nextnode, matched)
-                if not nav.pop_edge():
-                    # Short-circuit and finish the loop if pop_edge() returns False
-                    break
-
-    def _navigate_from_edge(self, prefix: str, nextnode: int, matched: str) -> None:
-        """Navigate along an edge, accepting partial and full matches"""
-        # Go along the edge as long as the navigator is accepting
-        b = self._b
-        lenp = len(prefix)
-        j = 0
-        nav = self._nav
-        while j < lenp and nav.accepting():
-            # See if the navigator is OK with accepting the current character
-            if not nav.accepts(prefix[j]):
-                # Nope: we're done with this edge
-                return
-            # So far, we have a match: add a letter to the matched path
-            matched += prefix[j]
-            j += 1
-            # Check whether the next prefix character is a vertical bar,
-            # denoting finality
-            final = False
-            if j < lenp:
-                if prefix[j] == "|":
-                    final = True
-                    j += 1
-            elif nextnode == 0 or b[nextnode] & 0x80:
-                # If we're at the final char of the prefix and the next node is final,
-                # set the final flag as well (there is no trailing
-                # vertical bar in this case)
-                final = True
-            # Tell the navigator where we are
-            nav.accept(matched, final)
-        # We're done following the prefix for as long as it goes and
-        # as long as the navigator was accepting
-        if j < lenp:
-            # We didn't complete the prefix, so the navigator must no longer
-            # be interested (accepting): we're done
-            return
-        if nextnode != 0 and nav.accepting():
-            # Gone through the entire edge and still have rack letters left:
-            # continue with the next node
-            self._navigate_from_node(nextnode, matched)
-
-    def go(self) -> None:
-        """Perform the navigation using the given navigator"""
-        # The ship is ready to go
-        if self._nav.accepting():
-            # Leave shore and navigate the open seas
-            self._navigate_from_node(self._root_offset, "")


### PR DESCRIPTION
## Summary

This PR migrates performance-critical methods from Python to C++ and enables Python Stable ABI for portable wheel distribution.

**Key improvements:**
- **C++ implementations**: Migrated core lookup methods (`lookup()`, `lookup_ksnid()`, `lookup_id()`, `lemma_forms()`) to C++ for significant performance gains
- **Stable ABI wheels**: Enabled abi3 support - one CPython wheel now works across Python 3.9-3.14+ (instead of separate wheels per version)
- **CI/CD optimization**: Updated workflows to build fewer wheels (~40% reduction) while maintaining comprehensive test coverage across 8 Python versions
- **Code cleanup**: Removed 195 lines of duplicate Python code, added type checking with abstract method stubs

**Performance impact:**
- `lookup_id()`: ~30× reduction in Python↔C++ boundary crossings
- Hash-based deduplication in C++ (O(1) vs O(n²))
- All hot paths now execute in native compiled code

**Code changes:**
- 2,519 lines added (mostly C++ implementations)
- 543 lines removed (duplicate Python code)
- 13 files changed

## Test plan

- [x] All 13 existing tests pass on Python 3.11
- [x] Type checking passes (mypy 0 errors)
- [x] CI tests passed on all 8 Python versions (3.9-3.14, PyPy 3.9-3.10)
- [x] Verified abi3 wheel builds correctly and installs on CPython 3.11
- [x] Abstract method stubs raise NotImplementedError with helpful messages

**Pre-merge checklist:**
- [ ] CI/CD passes on all platforms
- [ ] Wheel builds succeed for all target platforms
- [ ] Performance benchmarks show expected improvements (optional)

## Implementation details

**C++ files added:**
- `src/islenska/bincompress.cpp/h` - BinCompressed C++ implementation
- `src/islenska/dawgdictionary.cpp/h` - DAWG dictionary C++ implementation

**Python changes:**
- `src/islenska/bincompress.py` - Hybrid wrapper + abstract base class
- `src/islenska/dawgdictionary.py` - Reduced from 410 lines (now wraps C++)
- `src/islenska/bin_build.py` - Added `py_limited_api` for abi3
- `setup.py` - Configured bdist_wheel for stable ABI

**CI/CD updates:**
- `.github/workflows/wheels.yml` - Build cp39-abi3 instead of cp39/cp310/cp311/...
- `.github/workflows/python-package.yml` - Test on 8 Python versions (was 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)