### PR TITLE
Add add_compound_hyphens flag and compound support to case lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,24 @@ Lookups that are resolved via the compounding algorithm have a `bin_id` of zero.
 Note that the compounding algorithm will occasionally recognize nonexistent
 words, for instance spelling errors, as compounds.
 
-If desired, the compounding algorithm can be disabled
+If you would rather receive the bare, concatenated word form without these
+inserted hyphens, create the `Bin` instance with `add_compound_hyphens=False`:
+
+```python
+>>> b = Bin(add_compound_hyphens=False)
+>>> b.lookup("síamskattarkjóll")
+('síamskattarkjóll', [
+    (ord='síamskattarkjóll', kk/alm/0, bmynd='síamskattarkjóll', NFET)
+])
+```
+
+This suppresses only the synthetic boundaries that the algorithm discovers;
+hyphens that are part of the queried word, or that occur in BÍN itself (such
+as `Vestur-Þýskaland`), are always returned as-is. The `get_compound()`
+function (see below) is unaffected by this flag and always marks the component
+boundaries, since exposing the compound structure is its sole purpose.
+
+If desired, the compounding algorithm can be disabled altogether
 via an optional flag; see the documentation below.
 
 # Examples
@@ -296,6 +313,7 @@ constructor call:
 | `add_negation`    | `True`    | For adjectives, find forms with the prefix `ó` even if only the non-prefixed version is present in BÍN. Example: find `ófíkinn` because `fíkinn` is in BÍN. |
 | `add_legur`       | `True`    | For adjectives, find all forms with an "adjective-like" suffix, i.e. `-legur`, `-leg`, etc. even if they are not present in BÍN. Example: `sólarolíulegt`. |
 | `add_compounds`   | `True`    | Find compound words that can be derived from BinPackage's collection of allowed prefixes and suffixes. The algorithm finds the compound word with the fewest components and the longest suffix. Example: `síamskattar-kjóll`. |
+| `add_compound_hyphens` | `True` | Mark the component boundaries that the compounding algorithm discovers with a hyphen in the `ord` and `bmynd` fields (`síamskattar-kjóll`). Set to `False` to get the bare, concatenated form instead (`síamskattarkjóll`). This affects only the synthetic boundaries found by the algorithm; hyphens that are part of the queried word, or that occur in BÍN itself (e.g. `Vestur-Þýskaland`), are always preserved. |
 | `replace_z`       | `True`    | Find words containing `tzt` and `z` by replacing these strings by `st` and `s`, respectively. Example: `veitzt` -> `veist`. |
 | `only_bin`        | `False`   | Find only word forms that are originally present in BÍN, disabling all of the above described flags. |
 
@@ -510,8 +528,10 @@ call the `lookup_cats` function:
 ```
 
 The function returns a `Set[str]` with all possible word classes/categories
-of the word form. If the word is not found in BÍN, or recognized using the
-compounding algorithm, the function returns an empty set.
+of the word form. Word forms that are not present in BÍN are resolved via the
+compounding algorithm where possible (e.g. `borgarstjórnarminnihlutinn` yields
+`{'kk'}`); an empty set is returned only when the word can neither be found in
+BÍN nor interpreted as a compound.
 
 `lookup_cats()` has the following parameters:
 
@@ -531,9 +551,11 @@ To look up the possible lemmas/headwords and classes/categories of a word
 ```
 
 The function returns a `Set[Tuple[str, str]]` where each tuple contains
-a lemma/headword and a class/category, respectively.
-If the word is not found in BÍN, or recognized using the
-compounding algorithm, the function returns an empty set.
+a lemma/headword and a class/category, respectively. Word forms that are not
+present in BÍN are resolved via the compounding algorithm where possible (e.g.
+`borgarstjórnarminnihlutinn` yields `{('borgarstjórnar-minnihluti', 'kk')}`);
+an empty set is returned only when the word can neither be found in BÍN nor
+interpreted as a compound.
 
 `lookup_lemmas_and_cats()` has the following parameters:
 
@@ -739,6 +761,12 @@ alternative that supports more selective queries.
 The function returns a `List[BinEntry]`. As with the other case-lookup
 functions below, the order of entries in the list is not guaranteed.
 
+If the lemma is not present in BÍN but can be resolved as a compound word,
+the forms of its head (last component) are enumerated and re-prefixed, e.g.
+`lookup_forms("síamskattarkjóll", "kk", "ÞGF")` yields `síamskattar-kjól`,
+`síamskattar-kjólnum`, `síamskattar-kjólum` and `síamskattar-kjólunum`. The
+inserted hyphen follows the [`add_compound_hyphens`](#bin-constructor) flag.
+
 ## `lookup_nominative()`, `lookup_accusative()`, `lookup_dative()`, `lookup_genitive()`
 
 These four functions return the inflectional forms of a word's lemma(s)
@@ -781,6 +809,16 @@ Each function returns `List[BinEntry]`. The order of entries within the
 returned list is not guaranteed (results are derived from a `set`); the
 example outputs above show one possible ordering.
 
+A word form that is not present in BÍN but can be interpreted as a compound
+is resolved by casting its head (last component) and re-prefixing the result,
+just as `lookup()` does — so `lookup_nominative("síamskattarkjólnum", cat="kk")`
+returns `(ord='síamskattar-kjóll', bmynd='síamskattar-kjóllinn', NFETgr)`. The
+inserted hyphen follows the [`add_compound_hyphens`](#bin-constructor) flag,
+while hyphens that are part of the queried word are always kept. Compounding
+is not attempted when a `bin_id` is supplied (a constructed compound has no id
+of its own), nor when the word does occur in BÍN but is excluded by the `cat`
+or `lemma` constraints.
+
 ## `cast_to_accusative()`, `cast_to_dative()`, `cast_to_genitive()`
 
 Cast a single word from nominative case into another case, returning the
@@ -802,6 +840,10 @@ unchanged.
 The casting is context-free: the functions only see one word at a time.
 That means an ambiguous form may not be cast as intended in your
 sentence. To narrow the choice you can supply a `filter_func`.
+
+Compound words are cast by resolving their head, so a compound that is not in
+BÍN is still cast — `cast_to_accusative("Vestur-hestur")` gives `Vestur-hest`.
+Hyphens that are part of the input are preserved in the result.
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
@@ -835,6 +877,10 @@ to inspect compound structure.
 The function returns `Tuple[str, List[BinEntry]]` — the resolved search
 key and a list of compound `BinEntry` interpretations. The list is empty
 when no compound interpretation is found.
+
+This function always marks the component boundaries with hyphens, even when
+the `Bin` instance was created with `add_compound_hyphens=False`, since
+exposing the compound structure is the whole point of the function.
 
 ## `soft_hyphenate()` function
 

--- a/src/islenska/bindb.py
+++ b/src/islenska/bindb.py
@@ -186,6 +186,14 @@ class Bin:
         self._add_legur = options.pop("add_legur", True)
         self._add_compounds = options.pop("add_compounds", True)
         self._replace_z = options.pop("replace_z", True)
+        # When True (the default), the compounding algorithm marks the
+        # component boundaries it discovers with a hyphen in the 'ord' and
+        # 'bmynd' fields ('síamskattar-kjóll'). Set to False to get the bare,
+        # concatenated form ('síamskattarkjóll'). This only affects the
+        # synthetic boundaries found by the algorithm; hyphens that are part
+        # of the queried word, or that occur in BÍN itself (e.g.
+        # 'Vestur-Þýskaland'), are always preserved.
+        self._add_compound_hyphens = options.pop("add_compound_hyphens", True)
         if options.pop("only_bin", False):
             # If only_bin is set, disable all additions/modifications
             self._add_negation = False
@@ -391,16 +399,22 @@ class Bin:
         at_sentence_start: bool,
         lookup_func: LookupFunc[_T],
         ctor: EntryCtor[_T],
+        *,
+        insert_hyphen: bool = True,
     ) -> ResultTuple[_T]:
         """Return a list of matching entries for this word,
-        when interpreted as a compound word"""
+        when interpreted as a compound word. If insert_hyphen is False,
+        the boundary that the compounding algorithm discovers is not marked
+        with a hyphen, i.e. the bare concatenated form is returned. Hyphens
+        and spaces that are already present in ``w`` are always respected."""
         m: List[_T]
         if " " in w:
             # The word is a multi-word compound, such as
             # 'félags- og barnamálaráðherra': Look at the last part only
             prefix, suffix = w.rsplit(" ", maxsplit=1)
             w_suffix, m = self._compound_meanings(
-                suffix, suffix.lower(), False, lookup_func, ctor
+                suffix, suffix.lower(), False, lookup_func, ctor,
+                insert_hyphen=insert_hyphen,
             )
             if not m:
                 return w, m
@@ -419,13 +433,16 @@ class Bin:
             # look at the suffix only
             prefix, suffix = w.rsplit("-", maxsplit=1)
             _, m = self._compound_meanings(
-                suffix, suffix.lower(), False, lookup_func, ctor
+                suffix, suffix.lower(), False, lookup_func, ctor,
+                insert_hyphen=insert_hyphen,
             )
             if not m:
                 return w, m
             # For words such as 'Ytri-Hnaus', retain the uppercasing of the suffix
             uppercase_suffix = suffix[0].isupper() and suffix[1:].islower()
             w = prefix + "-" + suffix
+            # The hyphen here belongs to the queried word, so it is always
+            # retained, regardless of the insert_hyphen setting
             m = self._prefix_meanings(
                 m, prefix, ctor, uppercase_suffix=uppercase_suffix
             )
@@ -442,8 +459,10 @@ class Bin:
             return w, []
         cw = self._select_compound_candidate(candidates, lookup_func)
         # This looks like a compound word:
-        # use the meaning of its last part
-        prefix = "-".join(cw[0:-1])
+        # use the meaning of its last part. The component boundaries are
+        # marked with hyphens only if insert_hyphen is True; otherwise the
+        # prefix components are concatenated directly.
+        prefix = ("-" if insert_hyphen else "").join(cw[0:-1])
         # Lookup the entries that match the last part, setting
         # the compound flag if we actually have a compound word
         m = lookup_func(cw[-1], compound=bool(prefix))
@@ -459,7 +478,9 @@ class Bin:
             # (nouns, verbs, adjectives, adverbs)
             m = self.open_cats(m)
         # Add the prefix to the remaining word lemmas
-        return return_w, self._prefix_meanings(m, prefix, ctor)
+        return return_w, self._prefix_meanings(
+            m, prefix, ctor, insert_hyphen=insert_hyphen
+        )
 
     def _lookup(
         self,
@@ -468,10 +489,14 @@ class Bin:
         auto_uppercase: bool,
         lookup_func: LookupFunc[_T],
         ctor: EntryCtor[_T],
+        *,
+        insert_hyphen: bool = True,
     ) -> ResultTuple[_T]:
         """Lookup a simple or compound word in the database and
         return its meaning(s). This function checks for abbreviations,
-        upper/lower case variations, etc."""
+        upper/lower case variations, etc. The insert_hyphen flag controls
+        whether compound-component boundaries found by the compounding
+        algorithm are marked with a hyphen (see _compound_meanings())."""
 
         # Start with a straightforward, cached lookup of the word as-is
         lower_w = w
@@ -555,7 +580,8 @@ class Bin:
         if not m and self._add_compounds:
             # Still nothing: check compound words
             w, m = self._compound_meanings(
-                w, lower_w, at_sentence_start, lookup_func, ctor
+                w, lower_w, at_sentence_start, lookup_func, ctor,
+                insert_hyphen=insert_hyphen,
             )
 
         if not m and self._add_negation and lower_w.startswith("ó"):
@@ -592,6 +618,7 @@ class Bin:
                 auto_uppercase,
                 lookup_func,
                 ctor,
+                insert_hyphen=insert_hyphen,
             )
             if m:
                 # Return the word form that was actually found
@@ -726,6 +753,24 @@ class Bin:
             auto_uppercase,
             self._meanings_cache_lookup,
             make_bin_entry,
+            insert_hyphen=self._add_compound_hyphens,
+        )
+
+    def _lookup_keep_hyphens(
+        self, w: str, at_sentence_start: bool = False, auto_uppercase: bool = False
+    ) -> ResultTuple[BinEntry]:
+        """Like lookup(), but always marks compound-component boundaries with
+        a hyphen, regardless of the add_compound_hyphens flag. Used internally
+        by the case-casting functions, which rely on the hyphen to locate the
+        boundary between prefix and suffix; the hyphen itself does not appear
+        in their (concatenated) output."""
+        return self._lookup(
+            w,
+            at_sentence_start,
+            auto_uppercase,
+            self._meanings_cache_lookup,
+            make_bin_entry,
+            insert_hyphen=True,
         )
 
     def lookup_ksnid(
@@ -738,6 +783,7 @@ class Bin:
             auto_uppercase,
             self._ksnid_cache_lookup,
             Ksnid.make,
+            insert_hyphen=self._add_compound_hyphens,
         )
 
     def lookup_id(self, bin_id: int) -> KsnidList:
@@ -753,6 +799,7 @@ class Bin:
             False,
             self._ksnid_cache_lookup,
             Ksnid.make,
+            insert_hyphen=self._add_compound_hyphens,
         )
         return set(mm.ofl for mm in m)
 
@@ -766,6 +813,7 @@ class Bin:
             False,
             self._ksnid_cache_lookup,
             Ksnid.make,
+            insert_hyphen=self._add_compound_hyphens,
         )
         return set((mm.ord, mm.ofl) for mm in m)
 
@@ -774,16 +822,30 @@ class Bin:
         This is mainly used to retrieve inflection forms of nouns, where
         we want to retrieve singular and plural, definite and indefinite
         forms in particular cases. Note that lookup_variants() below is
-        a more flexible alternative to this function."""
+        a more flexible alternative to this function. If the lemma is not
+        found in BÍN but can be resolved as a compound word, the forms of
+        its head are enumerated and re-prefixed."""
         assert self._bc is not None
-        mset = self._bc.lookup_case(
-            lemma,
-            case.upper().replace("GR", "gr"),
-            lemma=lemma,
-            cat=cat,
-            all_forms=True,
+        bc: BinCompressed = self._bc
+        norm_case = case.upper().replace("GR", "gr")
+        m = self._filter_meanings(
+            bc.lookup_case(lemma, norm_case, lemma=lemma, cat=cat, all_forms=True)
         )
-        return self._filter_meanings(mset)
+        if m or bc.contains(lemma):
+            # Either the lemma was found, or it is present in BÍN as a non-lemma
+            # surface form (and thus deliberately yields nothing here): only a
+            # lemma that is absent from BÍN is a candidate for compounding.
+            return m
+
+        def suffix_forms_lookup(key: str, compound: bool = False) -> BinEntryList:
+            """Enumerate the forms of a compound head (the last component),
+            in the requested case. The head is a genuine BÍN word, so no
+            further compounding or lemma/id constraints apply."""
+            return self._filter_meanings(
+                bc.lookup_case(key, norm_case, cat=cat, all_forms=True)
+            )
+
+        return self._compound_case(lemma, suffix_forms_lookup)
 
     def lookup_variants(
         self,
@@ -817,7 +879,10 @@ class Bin:
             klist = self._filter_ksnid(mlist)
             return [k for k in klist if compound or k.birting != "S"]
 
-        _, m = self._lookup(w, False, False, variant_lookup, Ksnid.make)
+        _, m = self._lookup(
+            w, False, False, variant_lookup, Ksnid.make,
+            insert_hyphen=self._add_compound_hyphens,
+        )
         return m
 
     def lookup_lemmas(self, lemma: str) -> ResultTuple[BinEntry]:
@@ -853,6 +918,30 @@ class Bin:
         assert self._bc is not None
         return self._filter_meanings(self._bc.raw_nominative(w))
 
+    def _compound_case(
+        self, w: str, suffix_lookup: LookupFunc[BinEntry]
+    ) -> BinEntryList:
+        """Resolve case forms for a word that is not present in BÍN as a whole
+        but can be interpreted as a compound. The compounding algorithm splits
+        ``w``; ``suffix_lookup`` is then applied to the head (the last
+        component) to obtain its forms in the desired case, and the prefix is
+        prepended to each result. Component boundaries discovered by the
+        algorithm honour the add_compound_hyphens flag, while hyphens and
+        spaces that are part of ``w`` itself are always retained — exactly as
+        in lookup(). Returns [] when compounding is disabled or ``w`` has no
+        compound interpretation."""
+        if not self._add_compounds:
+            return []
+        _, m = self._compound_meanings(
+            w,
+            w.lower(),
+            False,
+            suffix_lookup,
+            make_bin_entry,
+            insert_hyphen=self._add_compound_hyphens,
+        )
+        return m
+
     def _lookup_case(
         self,
         case_func: Callable[..., Set[BinEntryTuple]],
@@ -868,7 +957,7 @@ class Bin:
     ) -> BinEntryList:
         """Shared implementation of lookup_nominative/accusative/dative/genitive."""
         assert self._bc is not None
-        return self._filter_meanings(case_func(
+        m = self._filter_meanings(case_func(
             w,
             cat=cat,
             lemma=lemma,
@@ -878,6 +967,36 @@ class Bin:
             all_forms=all_forms,
             inflection_filter=inflection_filter,
         ))
+        if m or bin_id is not None or self.contains(w):
+            # We resolve a compound only when the word is genuinely absent from
+            # BÍN, mirroring lookup(). So we stop here if anything was found, or
+            # a specific BÍN id was requested (a constructed compound has no id
+            # of its own), or the word does occur in BÍN but failed the
+            # cat/lemma/case constraints above (in which case the empty result
+            # is intentional and must not be second-guessed by compounding).
+            return m
+
+        def suffix_case_lookup(key: str, compound: bool = False) -> BinEntryList:
+            """Case forms of a compound head. The whole-word lemma/bin_id are
+            not propagated here, as they identify the compound, not its head;
+            the cat constraint, however, does apply to the head."""
+            return self._filter_meanings(case_func(
+                key,
+                cat=cat,
+                lemma=None,
+                utg=None,
+                singular=singular,
+                indefinite=indefinite,
+                all_forms=all_forms,
+                inflection_filter=inflection_filter,
+            ))
+
+        m = self._compound_case(w, suffix_case_lookup)
+        if lemma is not None:
+            # Restrict to the requested lemma, which for a compound is the
+            # whole-word lemma (matched with or without inserted hyphens)
+            m = [e for e in m if lemma in (e.ord, e.ord.replace("-", ""))]
+        return m
 
     def lookup_nominative(
         self,
@@ -994,7 +1113,7 @@ class Bin:
         # or whether a word such as 'við' is actually a preposition.
         return self._cast_to_case(
             w,
-            self.lookup,
+            self._lookup_keep_hyphens,
             self.lookup_accusative,
             filter_func=filter_func,
         )
@@ -1010,7 +1129,7 @@ class Bin:
         # or whether a word such as 'við' is actually a preposition.
         return self._cast_to_case(
             w,
-            self.lookup,
+            self._lookup_keep_hyphens,
             self.lookup_dative,
             filter_func=filter_func,
         )
@@ -1026,7 +1145,7 @@ class Bin:
         # or whether a word such as 'við' is actually a preposition.
         return self._cast_to_case(
             w,
-            self.lookup,
+            self._lookup_keep_hyphens,
             self.lookup_genitive,
             filter_func=filter_func,
         )
@@ -1035,10 +1154,14 @@ class Bin:
         self, w: str, at_sentence_start: bool = False
     ) -> ResultTuple[BinEntry]:
         """Lookup a word in the database and return its meaning(s),
-        prioritizing returning its compound structure."""
+        prioritizing returning its compound structure. The component
+        boundaries are always marked with hyphens, even when the instance
+        was created with add_compound_hyphens=False, since exposing the
+        compound structure is the whole purpose of this function."""
 
         w, m = self._compound_meanings(
-            w, w.lower(), at_sentence_start, self._meanings_cache_lookup, make_bin_entry
+            w, w.lower(), at_sentence_start, self._meanings_cache_lookup,
+            make_bin_entry, insert_hyphen=True,
         )
 
         return w, m

--- a/test/test_bin.py
+++ b/test/test_bin.py
@@ -416,6 +416,72 @@ def test_compounds() -> None:
     assert set(lc) == {("fjármála- og efnahags-ráðherra", "kk")}
 
 
+def test_no_compound_hyphens() -> None:
+    """The add_compound_hyphens=False flag suppresses the synthetic hyphens
+    that the compounding algorithm inserts at the boundaries it discovers,
+    while leaving hyphens that belong to the queried word, or that occur in
+    BÍN, untouched."""
+    db = Bin()  # Default: add_compound_hyphens=True
+    nh = Bin(add_compound_hyphens=False)
+
+    # A plain compound: the synthetic boundary is dropped in the lemma (ord)
+    # and in every inflection form (bmynd)
+    _, m = db.lookup("síamskattarkjólanna")
+    assert m[0].ord == "síamskattar-kjóll" and m[0].bmynd == "síamskattar-kjólanna"
+    _, m = nh.lookup("síamskattarkjólanna")
+    assert len(m) == 1
+    assert m[0].ord == "síamskattarkjóll" and m[0].bmynd == "síamskattarkjólanna"
+    assert m[0].bin_id == 0 and m[0].mark == "EFFTgr"
+
+    # Same for the Ksnid variant of lookup
+    _, mk = nh.lookup_ksnid("síamskattarkjólanna")
+    assert mk[0].ord == "síamskattarkjóll" and mk[0].bmynd == "síamskattarkjólanna"
+
+    # ...and for grammatical variants
+    v = nh.lookup_variants("síamskattarkjóll", "kk", "ÞGF")
+    assert v and all(
+        e.ord == "síamskattarkjóll" and "-" not in e.bmynd for e in v
+    )
+
+    # A three-part compound concatenates fully, with no internal hyphens
+    _, m = nh.lookup("alþjóðaviðskiptastofnunin")
+    assert m[0].ord == "alþjóðaviðskiptastofnun"
+    assert m[0].bmynd == "alþjóðaviðskiptastofnunin"
+
+    # lookup_cats / lookup_lemmas_and_cats respect the flag too
+    assert nh.lookup_lemmas_and_cats("síamskattarkjólanna") == {
+        ("síamskattarkjóll", "kk")
+    }
+    assert nh.lookup_cats("síamskattarkjólanna") == {"kk"}
+
+    # A hyphen that is part of the queried word is always preserved, even
+    # when the word is resolved as a compound (bin_id == 0)
+    _, m = nh.lookup("fjármála-ráðherra")
+    assert m and all(e.ord == "fjármála-ráðherra" and e.bin_id == 0 for e in m)
+
+    # A hyphen that occurs in BÍN itself is always preserved
+    _, m = nh.lookup("Vestur-Þýskaland")
+    assert m and all(e.ord == "Vestur-Þýskaland" and e.bin_id != 0 for e in m)
+
+    # In a multi-word compound the user's own separators are kept, while only
+    # the synthetic boundary before the head is dropped
+    _, m = db.lookup("fjármála- og efnahagsráðherra")
+    assert m[0].ord == "fjármála- og efnahags-ráðherra"
+    _, m = nh.lookup("fjármála- og efnahagsráðherra")
+    assert m[0].ord == "fjármála- og efnahagsráðherra"
+
+    # get_compound always exposes the compound structure with hyphens,
+    # regardless of the flag
+    _, m = nh.get_compound("síamskattarkjóll")
+    assert m[0].ord == "síamskattar-kjóll" and m[0].bmynd == "síamskattar-kjóll"
+
+    # Case casting is unaffected: it never emits the synthetic hyphen in either
+    # mode, and always keeps a legitimate one
+    assert nh.cast_to_dative("síamskattarkjóll") == "síamskattarkjól"
+    assert db.cast_to_dative("síamskattarkjóll") == "síamskattarkjól"
+    assert nh.cast_to_genitive("Vestur-Þýskaland") == "Vestur-Þýskalands"
+
+
 def test_gauksstadamal_uses_deepest_split() -> None:
     """`gauksstaðamál` should parse via the same 3-part split as
     `gauksstaðamálið` so that downstream consumers see the full
@@ -642,6 +708,20 @@ def test_casting() -> None:
     assert db.cast_to_dative("Vestur-Þýskaland") == "Vestur-Þýskalandi"
     assert db.cast_to_genitive("Vestur-Þýskaland") == "Vestur-Þýskalands"
 
+    # A user-hyphenated compound that is not itself in BÍN is cast by resolving
+    # its head via the compounding algorithm, consistent with lookup(). The
+    # contrived 'Vestur-hestur' is not a BÍN entry, but its head 'hestur'
+    # inflects, so the whole word can now be cast (it was returned unchanged
+    # before the case-lookup functions gained compound support).
+    assert not db.contains("Vestur-hestur")
+    assert db.cast_to_accusative("Vestur-hestur") == "Vestur-hest"
+    assert db.cast_to_dative("Vestur-hestur") == "Vestur-hesti"
+    assert db.cast_to_genitive("Vestur-hestur") == "Vestur-hests"
+    # The user's own hyphen is retained even when synthetic compound hyphens
+    # are switched off
+    db_nh = Bin(add_compound_hyphens=False)
+    assert db_nh.cast_to_accusative("Vestur-hestur") == "Vestur-hest"
+
     f: BinFilterFunc = lambda mm: sorted(
         mm, key=lambda m: "2" in m.mark or "3" in m.mark
     )
@@ -696,6 +776,100 @@ def test_forms():
     assert "kattarins" in om
     assert "katta" in om
     assert "kattanna" in om
+
+
+def test_compound_case_lookups() -> None:
+    """lookup_nominative/accusative/dative/genitive and lookup_forms resolve
+    compound words that are not present in BÍN as a whole, by enumerating the
+    forms of the head and re-prefixing them."""
+    db = Bin()
+
+    # lookup_<case>() casts a compound surface form. By default the result
+    # inherits number/definiteness from the input (síamskattarkjólnum is
+    # dative singular definite -> nominative singular definite only).
+    m = db.lookup_nominative("síamskattarkjólnum", cat="kk")
+    assert [(e.ord, e.bmynd, e.mark) for e in m] == [
+        ("síamskattar-kjóll", "síamskattar-kjóllinn", "NFETgr")
+    ]
+    # all_forms=True returns the whole paradigm in the requested case
+    m = db.lookup_nominative("síamskattarkjólnum", cat="kk", all_forms=True)
+    assert {e.bmynd for e in m} == {
+        "síamskattar-kjóll",
+        "síamskattar-kjóllinn",
+        "síamskattar-kjólar",
+        "síamskattar-kjólarnir",
+    }
+    assert all(e.ord == "síamskattar-kjóll" and e.bin_id == 0 for e in m)
+
+    m = db.lookup_dative("síamskattarkjóll", cat="kk", all_forms=True)
+    assert {e.bmynd for e in m} == {
+        "síamskattar-kjól",
+        "síamskattar-kjólnum",
+        "síamskattar-kjólum",
+        "síamskattar-kjólunum",
+    }
+    m = db.lookup_genitive("borgarstjórnarminnihlutinn", cat="kk")
+    assert [(e.ord, e.bmynd) for e in m] == [
+        ("borgarstjórnar-minnihluti", "borgarstjórnar-minnihlutans")
+    ]
+
+    # lookup_forms() works on a compound lemma, returning every form in the case
+    m = db.lookup_forms("síamskattarkjóll", "kk", "ÞGF")
+    assert {e.bmynd for e in m} == {
+        "síamskattar-kjól",
+        "síamskattar-kjólnum",
+        "síamskattar-kjólum",
+        "síamskattar-kjólunum",
+    }
+
+    # The add_compound_hyphens=False flag carries through to these functions
+    nh = Bin(add_compound_hyphens=False)
+    m = nh.lookup_nominative("síamskattarkjólnum", cat="kk")
+    assert [(e.ord, e.bmynd) for e in m] == [
+        ("síamskattarkjóll", "síamskattarkjóllinn")
+    ]
+    m = nh.lookup_forms("síamskattarkjóll", "kk", "ÞGF")
+    assert {e.bmynd for e in m} == {
+        "síamskattarkjól",
+        "síamskattarkjólnum",
+        "síamskattarkjólum",
+        "síamskattarkjólunum",
+    }
+    # A hyphen that is part of the queried word is always kept, even with the
+    # flag off
+    m = nh.lookup_nominative("fjármála-ráðherranum", cat="kk")
+    assert [(e.ord, e.bmynd) for e in m] == [
+        ("fjármála-ráðherra", "fjármála-ráðherrann")
+    ]
+
+    # Non-compound lookups are unaffected
+    m = db.lookup_nominative("hestinum", cat="kk")
+    assert [(e.ord, e.bmynd) for e in m] == [("hestur", "hesturinn")]
+    # A hyphenated word that occurs in BÍN is resolved directly, not compounded
+    m = db.lookup_genitive("Vestur-Þýskalandi")
+    assert m and all(e.ord == "Vestur-Þýskaland" and e.bin_id != 0 for e in m)
+
+    # The lemma keyword, for a compound, restricts to the whole-word lemma
+    # (matched with or without the inserted hyphens)
+    assert db.lookup_nominative(
+        "síamskattarkjólnum", cat="kk", lemma="síamskattarkjóll"
+    )
+    assert db.lookup_nominative(
+        "síamskattarkjólnum", cat="kk", lemma="síamskattar-kjóll"
+    )
+    assert not db.lookup_nominative("síamskattarkjólnum", cat="kk", lemma="kjóll")
+
+    # Compounding is not attempted when: a specific bin_id is requested (a
+    # constructed compound has none); compounds are disabled; the word is a
+    # misspelling that does not slice; or the word is in BÍN but fails the
+    # cat/lemma constraints (so the empty result is intentional).
+    assert not db.lookup_nominative("síamskattarkjólnum", cat="kk", bin_id=999999)
+    assert not Bin(add_compounds=False).lookup_nominative(
+        "síamskattarkjólnum", cat="kk"
+    )
+    assert not db.lookup_forms("kötur", "kk", "nf")
+    assert not db.lookup_forms("kettirnir", "kk", "nf")
+    assert not db.lookup_forms("köttur", "kvk", "nf")
 
 
 def test_variants() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -148,7 +148,7 @@ wheels = [
 
 [[package]]
 name = "islenska"
-version = "1.2.2"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cffi" },


### PR DESCRIPTION
## Summary

Three related changes to compound-word handling in the lookup API:

### 1. `add_compound_hyphens` flag (the headline)
A new `Bin()` option (default `True`, so existing behavior is unchanged). When set to `False`, the hyphens the compounding algorithm inserts at the boundaries it discovers (`síamskattar-kjóll`) are suppressed, yielding the bare concatenated form (`síamskattarkjóll`).

This addresses a recurring user complaint: callers had to strip these hyphens themselves, which was error-prone because they couldn't distinguish the *inserted* hyphens from **legitimate** ones. The flag suppresses **only** the synthetic boundaries; hyphens that are part of the queried word (e.g. `fjármála-ráðherra`) or that occur in BÍN itself (e.g. `Vestur-Þýskaland`) are always preserved. `get_compound()` ignores the flag and always shows structure, since that is its sole purpose.

### 2. Compound support in the case-lookup functions
`lookup_nominative/accusative/dative/genitive` and `lookup_forms` previously bypassed the compounding algorithm entirely (they hit the binary layer directly). They now resolve a word that is absent from BÍN by casting its head and re-prefixing, consistent with `lookup()`. Compounding is skipped when a `bin_id` is supplied, or when the word is in BÍN but excluded by the `cat`/`lemma`/`case` constraints (so deliberate empty results are not second-guessed).

As a side effect, `cast_to_*()` now also casts user-hyphenated compounds that are not in BÍN (e.g. `Vestur-hestur` → `Vestur-hest`); this is pinned by a test.

### 3. Documentation fix
The `lookup_cats()` / `lookup_lemmas_and_cats()` docs incorrectly claimed an empty set is returned for compound words; both have long resolved them. Corrected.

## Testing
- `uv run pytest` — 21 passed (added `test_no_compound_hyphens`, `test_compound_case_lookups`, and casting assertions in `test_casting`).
- `uv run pyright` — 0 errors.
- `ruff check src/islenska` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)