### PR TITLE
Don't compound a capitalized word that is genuinely in BÍN

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,10 +45,22 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Restore cached KRISTINsnid.csv.zip
+      id: cache-kristin
       uses: actions/cache@v4
       with:
         path: src/islenska/resources/KRISTINsnid.csv.zip
         key: kristin-csv-zip-v1
+
+    # The prepare-cache job warms the cache, but GitHub's cache service is
+    # eventually consistent: on the very first run (cold cache) the entry it
+    # just saved is not always queryable when this restore runs, so the cache
+    # can miss here even though prepare-cache succeeded. Download as a fallback
+    # so a miss is never fatal; this job then saves the cache for later jobs.
+    - name: Download KRISTINsnid.csv.zip
+      if: steps.cache-kristin.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p src/islenska/resources
+        wget -q -O src/islenska/resources/KRISTINsnid.csv.zip 'https://bin.arnastofnun.is/django/api/nidurhal/?file=KRISTINsnid.csv.zip'
 
     - name: Install BinPackage
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "islenska"
-version = "1.3.1"
+version = "1.3.2"
 description = "The vocabulary of modern Icelandic, encapsulated in a Python package"
 authors = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]
 maintainers = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]

--- a/src/islenska/bindb.py
+++ b/src/islenska/bindb.py
@@ -832,7 +832,7 @@ class Bin:
             bc.lookup_case(lemma, norm_case, lemma=lemma, cat=cat, all_forms=True)
         )
         if m or bc.contains(lemma) or (
-            not lemma.islower() and bc.contains(lemma.lower())
+            lemma != lemma.lower() and bc.contains(lemma.lower())
         ):
             # Either the lemma was found, or it is present in BÍN as a non-lemma
             # surface form (and thus deliberately yields nothing here): only a
@@ -975,7 +975,7 @@ class Bin:
             m
             or bin_id is not None
             or self.contains(w)
-            or (not w.islower() and self.contains(w.lower()))
+            or (w != w.lower() and self.contains(w.lower()))
         ):
             # We resolve a compound only when the word is genuinely absent from
             # BÍN, mirroring lookup(). So we stop here if anything was found, or

--- a/src/islenska/bindb.py
+++ b/src/islenska/bindb.py
@@ -831,10 +831,14 @@ class Bin:
         m = self._filter_meanings(
             bc.lookup_case(lemma, norm_case, lemma=lemma, cat=cat, all_forms=True)
         )
-        if m or bc.contains(lemma):
+        if m or bc.contains(lemma) or (
+            not lemma.islower() and bc.contains(lemma.lower())
+        ):
             # Either the lemma was found, or it is present in BÍN as a non-lemma
             # surface form (and thus deliberately yields nothing here): only a
-            # lemma that is absent from BÍN is a candidate for compounding.
+            # lemma that is absent from BÍN is a candidate for compounding. A
+            # capitalized lemma whose lowercase spelling is in BÍN ('Æðarvarp')
+            # is likewise a genuine word, not a compound to be split.
             return m
 
         def suffix_forms_lookup(key: str, compound: bool = False) -> BinEntryList:
@@ -967,13 +971,23 @@ class Bin:
             all_forms=all_forms,
             inflection_filter=inflection_filter,
         ))
-        if m or bin_id is not None or self.contains(w):
+        if (
+            m
+            or bin_id is not None
+            or self.contains(w)
+            or (not w.islower() and self.contains(w.lower()))
+        ):
             # We resolve a compound only when the word is genuinely absent from
             # BÍN, mirroring lookup(). So we stop here if anything was found, or
             # a specific BÍN id was requested (a constructed compound has no id
             # of its own), or the word does occur in BÍN but failed the
             # cat/lemma/case constraints above (in which case the empty result
             # is intentional and must not be second-guessed by compounding).
+            # The last clause covers a capitalized surface form (e.g. an address
+            # or sentence-initial word) whose canonical lowercase spelling is a
+            # genuine BÍN word ('Æðarvarp' -> 'æðarvarp'): casting that must use
+            # the whole-word entry, not split it into 'æðar-varp'. The empty
+            # result lets the caller retry with the lowercase form.
             return m
 
         def suffix_case_lookup(key: str, compound: bool = False) -> BinEntryList:

--- a/test/test_bin.py
+++ b/test/test_bin.py
@@ -758,23 +758,22 @@ def test_capitalized_word_in_bin_not_compounded() -> None:
         db.lookup_genitive,
     ):
         assert case_func("Æðarvarp") == []
-        assert all(
-            e.bin_id != 0 and "-" not in e.bmynd for e in case_func("æðarvarp")
-        )
+        lower = case_func("æðarvarp")
+        assert lower  # the lowercase form must resolve, or the test is vacuous
+        assert all(e.bin_id != 0 and "-" not in e.bmynd for e in lower)
 
     # lookup_forms() shares the same guard
     assert db.lookup_forms("Æðarvarp", "hk", "EF") == []
-    assert all(
-        e.bin_id != 0 and "-" not in e.bmynd
-        for e in db.lookup_forms("æðarvarp", "hk", "EF")
-    )
+    forms = db.lookup_forms("æðarvarp", "hk", "EF")
+    assert forms
+    assert all(e.bin_id != 0 and "-" not in e.bmynd for e in forms)
 
     # A genuine compound that is absent from BÍN in any casing is still resolved
     # by the compounder, as before
     assert not db.contains("síamskattarkjóll")
-    assert all(
-        e.bin_id == 0 for e in db.lookup_nominative("Síamskattarkjóll")
-    )
+    compound = db.lookup_nominative("Síamskattarkjóll")
+    assert compound
+    assert all(e.bin_id == 0 for e in compound)
 
 
 def test_forms():

--- a/test/test_bin.py
+++ b/test/test_bin.py
@@ -735,6 +735,48 @@ def test_casting() -> None:
     )
 
 
+def test_capitalized_word_in_bin_not_compounded() -> None:
+    """A capitalized surface form (e.g. an address or sentence-initial word)
+    whose canonical lowercase spelling is a genuine BÍN word must be resolved
+    via the whole-word entry, not split by the compounding algorithm. The
+    compounder only runs when the word is genuinely absent from BÍN; otherwise
+    'Æðarvarp' would be mis-resolved as the compound 'æðar-varp' (bin_id 0)
+    instead of the real noun 'æðarvarp' (bin_id != 0)."""
+    db = Bin()
+    # 'æðarvarp' is in BÍN; 'Æðarvarp' is merely its capitalization
+    assert db.contains("æðarvarp")
+    assert not db.contains("Æðarvarp")
+
+    # The case-lookup functions must not compound the capitalized form. They
+    # return [] (no whole-word match for the exact casing), leaving it to the
+    # caller to retry with the lowercase spelling, rather than emitting a
+    # spurious 'æðar-varp' split.
+    for case_func in (
+        db.lookup_nominative,
+        db.lookup_accusative,
+        db.lookup_dative,
+        db.lookup_genitive,
+    ):
+        assert case_func("Æðarvarp") == []
+        assert all(
+            e.bin_id != 0 and "-" not in e.bmynd for e in case_func("æðarvarp")
+        )
+
+    # lookup_forms() shares the same guard
+    assert db.lookup_forms("Æðarvarp", "hk", "EF") == []
+    assert all(
+        e.bin_id != 0 and "-" not in e.bmynd
+        for e in db.lookup_forms("æðarvarp", "hk", "EF")
+    )
+
+    # A genuine compound that is absent from BÍN in any casing is still resolved
+    # by the compounder, as before
+    assert not db.contains("síamskattarkjóll")
+    assert all(
+        e.bin_id == 0 for e in db.lookup_nominative("Síamskattarkjóll")
+    )
+
+
 def test_forms():
     db = Bin()
     l: List[BinEntry]

--- a/uv.lock
+++ b/uv.lock
@@ -148,7 +148,7 @@ wheels = [
 
 [[package]]
 name = "islenska"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "cffi" },


### PR DESCRIPTION
## Problem

The case-lookup family (`lookup_nominative`/`accusative`/`dative`/`genitive`) and `lookup_forms()` ran the word compounder on a **capitalized surface form whose canonical lowercase spelling is a genuine BÍN word**. As a result `Æðarvarp` resolved to the synthetic compound `æðar-varp` (`bin_id 0`) instead of the real noun `æðarvarp` (`bin_id 353172`).

This regressed `NounPhrase` declension in GreynirEngine, e.g. `NounPhrase("Æðarvarp 17").nominative` returned `Æðar-varp 17` instead of `Æðarvarp 17`.

## Root cause

The compounder is meant to fire only when a word is **genuinely absent from BÍN**. The guard in `_lookup_case()` and `lookup_forms()` only checked `contains(w)` with the exact casing — for `Æðarvarp` that is `False` (BÍN holds the lowercase `æðarvarp`), so it fell through to compounding and fabricated `æðar-varp`.

## Fix

Broaden that guard to also recognize a capitalized form whose lowercase spelling is in BÍN. The empty result for the exact casing then lets the caller retry with the lowercase form, exactly as before — this is the path GreynirEngine's `NounPhrase` already takes.

Genuine compounds absent from BÍN in any casing (`Síamskattarkjóll`) and user-hyphenated words (`Vestur-hestur`) still resolve via the compounder unchanged. The synthetic-hyphen contract of `lookup_*()` (controlled by `add_compound_hyphens`) is unchanged — this only stops compounding words that are real BÍN entries.

## Tests

- Added `test_capitalized_word_in_bin_not_compounded` as a regression test.
- Full suite passes (22 passed).

Version bumped to **1.3.2**. GreynirEngine will require `islenska>=1.3.2` once this is published to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)